### PR TITLE
fix interp selection

### DIFF
--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -68,15 +68,16 @@ class Registry:
             for key in keys:
                 if key in dialect.interps:
                     dialect_interp = dialect.interps[key]
-                    break
+                    if dialect not in fallback:  # use the first fallback
+                        fallback[dialect] = dialect_interp.fallback
 
-            if dialect_interp is None:  # not found, use default
+                    for sig, func in dialect_interp.table.items():
+                        if sig not in ret:
+                            ret[sig] = MethodImpl(dialect_interp, func)
+
+            if dialect not in fallback:
                 msg = ",".join(keys)
                 raise KeyError(f"Interpreter of {dialect.name} not found for {msg}")
-
-            for key, func in dialect_interp.table.items():
-                ret[key] = MethodImpl(dialect_interp, func)
-            fallback[dialect] = dialect_interp.fallback
         return ret, fallback
 
     def codegen(self, keys: Iterable[str]):

--- a/test/interp/test_select.py
+++ b/test/interp/test_select.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+import pytest
+
+from kirin.analysis.dataflow.forward import ForwardDataFlowAnalysis
+from kirin.dialects.py import stmts
+from kirin.interp import DialectInterpreter, ResultValue, impl
+from kirin.lattice import EmptyLattice
+from kirin.prelude import basic
+from kirin.worklist import WorkList
+
+
+@dataclass(init=False)
+class Interpreter(ForwardDataFlowAnalysis[EmptyLattice, WorkList]):
+    keys = ["test_interp", "main", "empty"]
+
+    @classmethod
+    def bottom_value(cls) -> EmptyLattice:
+        return EmptyLattice()
+
+    @classmethod
+    def default_worklist(cls) -> WorkList:
+        return WorkList()
+
+
+@stmts.dialect.register(key="test_interp")
+class DialectInterp(DialectInterpreter):
+
+    @impl(stmts.NewTuple)
+    def new_tuple(
+        self, interp: Interpreter, stmt: stmts.NewTuple, values: tuple
+    ) -> ResultValue:
+        return ResultValue(EmptyLattice())
+
+
+@basic
+def main(x):
+    return 1
+
+
+def test_interp():
+    interp = Interpreter(basic)
+    with pytest.raises(AttributeError):
+        interp.eval(main, (EmptyLattice(),))


### PR DESCRIPTION
we may consider remove the key selection feature as different analysis rely on different lattice (otherwise they endup to be the same analysis). So having dialect interpreter is prob sufficient. But let's do that in the future. fix #31 