### PR TITLE
rm dataclass decorator

### DIFF
--- a/src/kirin/analysis/dataflow/forward.py
+++ b/src/kirin/analysis/dataflow/forward.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import field
 from typing import Iterable, TypeVar
 
 from kirin.interp import AbstractInterpreter, Successor
@@ -12,11 +12,10 @@ ResultType = TypeVar("ResultType", bound=Lattice)
 WorkListType = TypeVar("WorkListType", bound=WorkList[Successor])
 
 
-@dataclass(init=False)
 class ForwardDataFlowAnalysis(AbstractInterpreter[ResultType, WorkListType]):
     """Abstract interpreter but record results for each SSA value."""
 
-    results: dict[SSAValue, ResultType] = field(default_factory=dict)
+    results: dict[SSAValue, ResultType] = field(init=False, default_factory=dict)
 
     def __init__(
         self, dialects: DialectGroup | Iterable[Dialect], *, fuel: int | None = None

--- a/src/kirin/analysis/dataflow/reachable.py
+++ b/src/kirin/analysis/dataflow/reachable.py
@@ -30,7 +30,6 @@ class CFGWorkList(WorkList[Successor]):
         super().push(item)
 
 
-@dataclass(init=False)
 class ReachableAnalysis(AbstractInterpreter[EmptyLattice, CFGWorkList]):
     keys = [
         "reachibility",

--- a/src/kirin/analysis/dataflow/typeinfer.py
+++ b/src/kirin/analysis/dataflow/typeinfer.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from kirin import ir
 from kirin.analysis.dataflow.forward import ForwardDataFlowAnalysis
 from kirin.dialects.py import types
@@ -12,7 +10,6 @@ from kirin.ir.nodes.stmt import Statement
 from kirin.worklist import WorkList
 
 
-@dataclass(init=False)
 class TypeInference(ForwardDataFlowAnalysis[TypeAttribute, WorkList[Successor]]):
     keys = ["typeinfer", "typeinfer.default"]
 

--- a/src/kirin/interp/abstract.py
+++ b/src/kirin/interp/abstract.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import field
 from typing import Generic, Iterable, TypeVar
 
 from kirin.interp.base import BaseInterpreter, InterpResult
@@ -16,12 +16,11 @@ WorkListType = TypeVar("WorkListType", bound=WorkList[Successor])
 # currently we may end up in infinite loop
 
 
-@dataclass(init=False)
 class AbstractInterpreter(
     Generic[ResultType, WorkListType], BaseInterpreter[ResultType]
 ):
-    bottom: ResultType = field(kw_only=True, repr=False)
-    worklist: WorkListType = field(kw_only=True, repr=False)
+    bottom: ResultType = field(init=False, kw_only=True, repr=False)
+    worklist: WorkListType = field(init=False, kw_only=True, repr=False)
 
     def __init__(
         self, dialects: DialectGroup | Iterable[Dialect], *, fuel: int | None = None

--- a/src/kirin/interp/base.py
+++ b/src/kirin/interp/base.py
@@ -1,8 +1,10 @@
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+
+from typing_extensions import dataclass_transform
 
 from kirin.exceptions import InterpreterError
 from kirin.interp.frame import Frame
@@ -49,8 +51,22 @@ class InterpResult(Generic[ValueType]):
             return ResultValue(self.value)
 
 
-@dataclass
-class BaseInterpreter(ABC, Generic[ValueType]):
+@dataclass_transform(field_specifiers=(field,))
+class InterpreterMeta(ABCMeta):
+    def __new__(
+        mcls: type,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        /,
+        init: bool = False,
+        **kwargs: Any,
+    ):
+        cls = super().__new__(mcls, name, bases, namespace, **kwargs)  # type: ignore
+        return dataclass(init=init)(cls)
+
+
+class BaseInterpreter(ABC, Generic[ValueType], metaclass=InterpreterMeta):
     """A base class for interpreters."""
 
     keys: ClassVar[list[str]]


### PR DESCRIPTION
fix #30, now interpreter does not need `dataclass` decorator anymore

cc: @kaihsin 