### PR TITLE
support rules to inline closure within same scope

### DIFF
--- a/src/kirin/rules/getfield.py
+++ b/src/kirin/rules/getfield.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from kirin import ir
+from kirin.dialects import func
+from kirin.rewrite import RewriteResult, RewriteRule
+
+
+@dataclass
+class InlineGetField(RewriteRule):
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, func.GetField):
+            return RewriteResult()
+
+        if not isinstance(node.obj.owner, func.Lambda):
+            return RewriteResult()
+
+        original = node.obj.owner.captured[node.field]
+        node.result.replace_by(original)
+        node.delete()
+        return RewriteResult(has_done_something=True)


### PR DESCRIPTION
this should give you what you want @kaihsin when a closure is used within the same region, the closure will be inlined. Still missing a pass (this will be a more complicated pass schedule) to get you there.

but now

```py
@basic_no_opt.add(dialect)
def unfolable(x: int, y: int):
    def inner():
        DummyStmt2(x, option="hello")
        DummyStmt2(y, option="hello")

    return inner


@basic_no_opt.add(dialect)
def main():
    x = DummyStmt2(1, option="hello")
    x = unfolable(x, x)
    return x()
```

will be structurelly equivalent to

```py
@basic_no_opt.add(dialect)
def target():
    x = DummyStmt2(1, option="hello")
    DummyStmt2(x, option="hello")
    DummyStmt2(x, option="hello")
    return
```
