### PR TITLE
decouple func from py.stmts

### DIFF
--- a/src/kirin/dialects/func/__init__.py
+++ b/src/kirin/dialects/func/__init__.py
@@ -12,6 +12,7 @@ from kirin.dialects.func.attrs import MethodType as MethodType, Signature as Sig
 from kirin.dialects.func.dialect import dialect as dialect
 from kirin.dialects.func.stmts import (
     Call as Call,
+    ConstantNone as ConstantNone,
     Function as Function,
     GetField as GetField,
     Invoke as Invoke,

--- a/src/kirin/dialects/func/interp.py
+++ b/src/kirin/dialects/func/interp.py
@@ -1,5 +1,12 @@
 from kirin.dialects.func.dialect import dialect
-from kirin.dialects.func.stmts import Call, GetField, Invoke, Lambda, Return
+from kirin.dialects.func.stmts import (
+    Call,
+    ConstantNone,
+    GetField,
+    Invoke,
+    Lambda,
+    Return,
+)
 from kirin.interp import DialectInterpreter, ResultValue, ReturnValue, concrete, impl
 from kirin.ir import Method
 
@@ -24,6 +31,12 @@ class Interpreter(DialectInterpreter):
     @impl(Return)
     def return_(self, interp: concrete.Interpreter, stmt: Return, values: tuple):
         return ReturnValue(values[0])
+
+    @impl(ConstantNone)
+    def const_none(
+        self, interp: concrete.Interpreter, stmt: ConstantNone, values: tuple[()]
+    ):
+        return ResultValue(None)
 
     @impl(GetField)
     def getfield(self, interp: concrete.Interpreter, stmt: GetField, values: tuple):

--- a/src/kirin/dialects/func/lower.py
+++ b/src/kirin/dialects/func/lower.py
@@ -3,8 +3,16 @@ import ast
 from kirin import ir
 from kirin.dialects.func.attrs import Signature
 from kirin.dialects.func.dialect import dialect
-from kirin.dialects.func.stmts import Call, Function, GetField, Invoke, Lambda, Return
-from kirin.dialects.py import stmts, types
+from kirin.dialects.func.stmts import (
+    Call,
+    ConstantNone,
+    Function,
+    GetField,
+    Invoke,
+    Lambda,
+    Return,
+)
+from kirin.dialects.py import types
 from kirin.exceptions import DialectLoweringError
 from kirin.lowering import Frame, FromPythonAST, LoweringState, Result
 
@@ -51,7 +59,7 @@ class FuncLowering(FromPythonAST):
 
     def lower_Return(self, state: LoweringState, node: ast.Return) -> Result:
         if node.value is None:
-            stmt = Return(state.append_stmt(stmts.Constant(None)).result)
+            stmt = Return(state.append_stmt(ConstantNone()).result)
             state.append_stmt(stmt)
         else:
             result = state.visit(node.value).expect_one()
@@ -109,7 +117,7 @@ class FuncLowering(FromPythonAST):
         # this is annoying, so we add a return statement at the end
         # so other control flows knows where to exit...
         # this can be a dead block if there is a return statement, but it's fine
-        none_const = stmts.Constant(None)
+        none_const = ConstantNone()
         return_none = Return(none_const.result)
         none_const.source = state.source
         return_none.source = state.source
@@ -120,7 +128,7 @@ class FuncLowering(FromPythonAST):
             and not func_frame.current_block.last_stmt.has_trait(ir.IsTerminator)
         ):
             func_frame.append_stmt(
-                Return(func_frame.append_stmt(stmts.Constant(None)).result)
+                Return(func_frame.append_stmt(ConstantNone()).result)
             )
 
         func_frame.append_block(func_frame.next_block)

--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -3,9 +3,11 @@ from typing import Union
 from kirin.decl import info, statement
 from kirin.dialects.func.attrs import MethodType, Signature
 from kirin.dialects.func.dialect import dialect
+from kirin.dialects.py import types
 from kirin.exceptions import VerificationError
 from kirin.ir import (
     CallableStmtInterface,
+    ConstantLike,
     HasParent,
     HasSignature,
     IsolatedFromAbove,
@@ -115,6 +117,19 @@ class Call(Statement):
 
     def print_impl(self, printer: Printer) -> None:
         _print_invoke_or_call(self, printer)
+
+
+@statement(dialect=dialect)
+class ConstantNone(Statement):
+    """A constant None value.
+
+    This is mainly used to represent the None return value of a function
+    to match Python semantics.
+    """
+
+    name = "const.none"
+    traits = frozenset({Pure(), ConstantLike()})
+    result: ResultValue = info.result(types.NoneType)
 
 
 @statement(dialect=dialect, init=False)

--- a/src/kirin/dialects/func/typeinfer.py
+++ b/src/kirin/dialects/func/typeinfer.py
@@ -3,7 +3,14 @@ from typing import Iterable
 from kirin import ir
 from kirin.analysis.dataflow.typeinfer import TypeInference
 from kirin.dialects.func.dialect import dialect
-from kirin.dialects.func.stmts import Call, GetField, Invoke, Lambda, Return
+from kirin.dialects.func.stmts import (
+    Call,
+    ConstantNone,
+    GetField,
+    Invoke,
+    Lambda,
+    Return,
+)
 from kirin.dialects.py import types
 from kirin.interp import DialectInterpreter, ResultValue, ReturnValue, impl
 
@@ -12,14 +19,15 @@ from kirin.interp import DialectInterpreter, ResultValue, ReturnValue, impl
 @dialect.register(key="typeinfer")
 class TypeInfer(DialectInterpreter):
 
+    @impl(ConstantNone)
+    def const_none(self, interp: TypeInference, stmt: ConstantNone, values: tuple[()]):
+        return ResultValue(types.NoneType)
+
     @impl(Return)
     def return_(
         self, interp: TypeInference, stmt: Return, values: tuple
     ) -> ReturnValue:
-        if not values:
-            return ReturnValue(types.NoneType)
-        else:
-            return ReturnValue(*values)
+        return ReturnValue(*values)
 
     @impl(Call)
     def call(self, interp: TypeInference, stmt: Call, values: tuple):


### PR DESCRIPTION
This PR introduce a new `ConstantLike` statement `ConstantNone` to represent a constant `None` value. This is mainly and only used by lowering from a Python function that returns `None` without depending on `py.stmts` so we don't need to allow entire Python semantics in a kernel function.

I'm not a huge fan of this solution, as this introduce duplication. I think we should think about breaking `py.stmts` dialect into smaller units and eventually remove duplications like this.

fix #98 