### PR TITLE
simplify lattice

### DIFF
--- a/src/kirin/analysis/dataflow/constprop.py
+++ b/src/kirin/analysis/dataflow/constprop.py
@@ -12,10 +12,6 @@ from kirin.lattice import Lattice, LatticeMeta, SingletonMeta
 @dataclass
 class ConstPropLattice(Lattice["ConstPropLattice"]):
 
-    @property
-    def parent_type(self) -> type["ConstPropLattice"]:
-        return ConstPropLattice
-
     @classmethod
     def top(cls) -> Any:
         return NotConst()
@@ -145,7 +141,7 @@ class PartialLambda(ConstPropLattice):
         return all(x.is_subseteq(y) for x, y in zip(self.captured, other.captured))
 
     def join(self, other: ConstPropLattice) -> ConstPropLattice:
-        if other.is_bottom():
+        if other is other.bottom():
             return self
 
         if not isinstance(other, PartialLambda):
@@ -209,7 +205,7 @@ class ConstPropFrameInfo:
 
 class ConstProp(ForwardExtra[ConstPropLattice, ConstPropFrameInfo]):
     keys = ["constprop", "empty"]
-    interp: Interpreter
+    lattice = ConstPropLattice
 
     def __init__(
         self,
@@ -231,10 +227,6 @@ class ConstProp(ForwardExtra[ConstPropLattice, ConstPropFrameInfo]):
             max_depth=max_depth,
             max_python_recursion_depth=max_python_recursion_depth,
         )
-
-    @classmethod
-    def bottom_value(cls) -> ConstPropLattice:
-        return ConstPropBottom()
 
     def try_eval_const(
         self, stmt: ir.Statement, args: tuple[Const, ...]

--- a/src/kirin/analysis/dataflow/forward.py
+++ b/src/kirin/analysis/dataflow/forward.py
@@ -1,7 +1,4 @@
-from dataclasses import field
 from typing import Generic, Iterable, TypeVar
-
-from typing_extensions import deprecated
 
 from kirin.interp import AbstractFrame, AbstractInterpreter
 from kirin.ir import Dialect, SSAValue
@@ -19,7 +16,6 @@ class ForwardFrame(AbstractFrame[LatticeElemType], Generic[LatticeElemType, Extr
 
 class ForwardExtra(
     AbstractInterpreter[ForwardFrame[LatticeElemType, ExtraType], LatticeElemType],
-    Generic[LatticeElemType, ExtraType],
 ):
     """Abstract interpreter but record results for each SSA value.
 
@@ -27,8 +23,6 @@ class ForwardExtra(
         LatticeElemType: The lattice element type.
         ExtraType: The type of extra information to be stored in the frame.
     """
-
-    results: dict[SSAValue, LatticeElemType] = field(init=False, default_factory=dict)
 
     def __init__(
         self,
@@ -65,11 +59,6 @@ class ForwardExtra(
 
     def new_method_frame(self, mt: Method) -> ForwardFrame[LatticeElemType, ExtraType]:
         return ForwardFrame.from_method(mt)
-
-
-@deprecated("use Forward instead")
-class ForwardDataFlowAnalysis(ForwardExtra[LatticeElemType, None]):
-    pass
 
 
 class Forward(ForwardExtra[LatticeElemType, None]):

--- a/src/kirin/analysis/dataflow/typeinfer.py
+++ b/src/kirin/analysis/dataflow/typeinfer.py
@@ -2,7 +2,7 @@ from kirin import ir
 from kirin.analysis.dataflow.forward import Forward
 from kirin.dialects.py import types
 from kirin.interp.base import InterpResult
-from kirin.ir import BottomType, TypeAttribute
+from kirin.ir import TypeAttribute
 from kirin.ir.method import Method
 from kirin.ir.nodes.region import Region
 from kirin.ir.nodes.stmt import Statement
@@ -10,10 +10,7 @@ from kirin.ir.nodes.stmt import Statement
 
 class TypeInference(Forward[TypeAttribute]):
     keys = ["typeinfer", "typeinfer.default"]
-
-    @classmethod
-    def bottom_value(cls) -> TypeAttribute:
-        return BottomType()
+    lattice = TypeAttribute
 
     def build_signature(self, stmt: Statement, args: tuple):
         """we use value here as signature as they will be types"""

--- a/src/kirin/decl/emit/typecheck.py
+++ b/src/kirin/decl/emit/typecheck.py
@@ -16,7 +16,7 @@ class EmitTypeCheck(BaseModifier):
         }
         body: list[str] = []
         for name, f in self.fields.args.items():
-            if f.type.is_top():
+            if f.type is f.type.top():
                 continue
 
             value_type = f"_args_{f.name}_type"
@@ -32,7 +32,7 @@ class EmitTypeCheck(BaseModifier):
                 body.extend(self._guard_ssa_type(f.name, value_type))
 
         for name, f in self.fields.results.items():
-            if f.type.is_top():
+            if f.type is f.type.top():
                 continue
 
             value_type = f"_results_{f.name}_type"

--- a/src/kirin/interp/base.py
+++ b/src/kirin/interp/base.py
@@ -1,11 +1,9 @@
 import sys
 from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Sequence, TypeVar
-
-from typing_extensions import dataclass_transform
+from typing import TYPE_CHECKING, Generic, Sequence, TypeVar
 
 from kirin.exceptions import InterpreterError
 from kirin.interp.frame import FrameABC
@@ -15,7 +13,7 @@ from kirin.ir import Dialect, DialectGroup, Region, Statement, traits
 from kirin.ir.method import Method
 
 if TYPE_CHECKING:
-    from kirin.interp.impl import Signature, StatementImpl
+    from kirin.interp.impl import Signature
 
 ValueType = TypeVar("ValueType")
 FrameType = TypeVar("FrameType", bound=FrameABC)
@@ -53,42 +51,16 @@ class InterpResult(Generic[ValueType]):
             return ResultValue(self.value)
 
 
-@dataclass_transform(field_specifiers=(field,))
 class InterpreterMeta(ABCMeta):
-    def __new__(
-        mcls: type,
-        name: str,
-        bases: tuple[type, ...],
-        namespace: dict[str, Any],
-        /,
-        init: bool = False,
-        **kwargs: Any,
-    ):
-        cls = super().__new__(mcls, name, bases, namespace, **kwargs)  # type: ignore
-        return dataclass(init=init)(cls)
+    pass
 
 
 class BaseInterpreter(ABC, Generic[FrameType, ValueType], metaclass=InterpreterMeta):
     """A base class for interpreters."""
 
-    keys: ClassVar[list[str]]
+    keys: list[str]
     """The name of the interpreter to select from dialects by order.
     """
-    dialects: DialectGroup
-    """The dialects to interpret."""
-
-    registry: dict["Signature", "StatementImpl"] = field(init=False, repr=False)
-    """A mapping of statement signature to their implementation.
-    """
-    fallbacks: dict[Dialect, "StatementImpl"] = field(init=False, repr=False)
-    state: InterpreterState[FrameType] = field(init=False, repr=False)
-    """The interpreter state.
-    """
-    fuel: int | None = field(default=None, init=False, kw_only=True)
-    """The fuel limit.
-    """
-    max_depth: int = field(default=128, init=False, kw_only=True)
-    max_python_recursion_depth: int = field(default=8192, init=False, kw_only=True)
 
     def __init__(
         self,

--- a/src/kirin/interp/value.py
+++ b/src/kirin/interp/value.py
@@ -102,7 +102,11 @@ class Err(Result[ValueType]):
         )
         args = ",".join(
             [
-                (f"{arg.name}" if arg.type.is_top() else f"{arg.name}:{arg.type}")
+                (
+                    f"{arg.name}"
+                    if arg.type is arg.type.top()
+                    else f"{arg.name}:{arg.type}"
+                )
                 for arg in region.blocks[0].args[1:]
             ]
         )

--- a/src/kirin/ir/attrs.py
+++ b/src/kirin/ir/attrs.py
@@ -91,10 +91,6 @@ class StructAttribute(Attribute, ABC):
 @dataclass(eq=False)
 class TypeAttribute(Attribute, Lattice["TypeAttribute"], metaclass=TypeAttributeMeta):
 
-    @property
-    def parent_type(self) -> type[TypeAttribute]:
-        return TypeAttribute
-
     def __or__(self, other: TypeAttribute):
         return self.join(other)
 
@@ -105,12 +101,6 @@ class TypeAttribute(Attribute, Lattice["TypeAttribute"], metaclass=TypeAttribute
     @classmethod
     def bottom(cls) -> BottomType:
         return BottomType()
-
-    def is_top(self):
-        return isinstance(self, AnyType)
-
-    def is_bottom(self):
-        return isinstance(self, BottomType)
 
     def is_subtype(self, other: TypeAttribute) -> bool:
         return self.is_subseteq(other)
@@ -134,7 +124,7 @@ class AnyType(TypeAttribute, metaclass=SingletonTypeMeta):
         return isinstance(other, AnyType)  # allow subclassing
 
     def is_equal(self, other: TypeAttribute) -> bool:
-        return other.is_top()
+        return other is self.top()
 
     def __hash__(self):
         return id(self)
@@ -152,7 +142,7 @@ class BottomType(TypeAttribute, metaclass=SingletonTypeMeta):
         return self
 
     def is_equal(self, other: TypeAttribute) -> bool:
-        return other.is_bottom()
+        return other is other.bottom()
 
     def is_subseteq(self, other: TypeAttribute) -> bool:
         return True

--- a/src/kirin/ir/ssa.py
+++ b/src/kirin/ir/ssa.py
@@ -114,7 +114,7 @@ class ResultValue(SSAValue):
         return id(self)
 
     def __repr__(self) -> str:
-        if self.type.is_top():
+        if self.type is self.type.top():
             type_str = ""
         else:
             type_str = f"[{self.type}]"

--- a/src/kirin/lattice.py
+++ b/src/kirin/lattice.py
@@ -15,21 +15,11 @@ class LatticeMeta(ABCMeta):
 class Lattice(ABC, Generic[LatticeParent], metaclass=LatticeMeta):
     """Abstract base class for lattices."""
 
-    @property
-    @abstractmethod
-    def parent_type(self) -> type[LatticeParent]: ...
-
     @abstractmethod
     def join(self, other: LatticeParent) -> LatticeParent: ...
 
     @abstractmethod
     def meet(self, other: LatticeParent) -> LatticeParent: ...
-
-    def is_bottom(self):
-        return self is self.bottom()
-
-    def is_top(self):
-        return self is self.top()
 
     @abstractmethod
     def is_subseteq(self, other: LatticeParent) -> bool: ...
@@ -38,9 +28,12 @@ class Lattice(ABC, Generic[LatticeParent], metaclass=LatticeMeta):
         return self.is_subseteq(other) and not other.is_subseteq(self)
 
     def __eq__(self, value: object) -> bool:
-        return isinstance(value, self.parent_type) and self.is_equal(value)
+        raise NotImplementedError(
+            "Equality is not implemented for lattices, use is_equal instead"
+        )
 
     def is_equal(self, other: LatticeParent) -> bool:
+        """Check if two lattices are equal."""
         if self is other:
             return True
         else:
@@ -54,8 +47,8 @@ class Lattice(ABC, Generic[LatticeParent], metaclass=LatticeMeta):
     @abstractmethod
     def top(cls) -> LatticeParent: ...
 
-    @abstractmethod
-    def __hash__(self) -> int: ...
+    def __hash__(self) -> int:
+        raise NotImplementedError("Hash is not implemented for lattices")
 
 
 class SingletonMeta(LatticeMeta):
@@ -117,21 +110,11 @@ class UnionMeta(LatticeMeta):
 class EmptyLattice(Lattice["EmptyLattice"], metaclass=SingletonMeta):
     """Empty lattice."""
 
-    @property
-    def parent_type(self) -> type[EmptyLattice]:
-        return EmptyLattice
-
     def join(self, other: EmptyLattice) -> EmptyLattice:
         return self
 
     def meet(self, other: EmptyLattice) -> EmptyLattice:
         return self
-
-    def is_bottom(self):
-        return True
-
-    def is_top(self):
-        return True
 
     @classmethod
     def bottom(cls):

--- a/test/dialects/pystmts/test_getitem.py
+++ b/test/dialects/pystmts/test_getitem.py
@@ -70,8 +70,8 @@ def test_getitem_typeinfer():
     assert tuple_const_slice.return_type.is_subseteq(
         types.Tuple[types.Float, types.String]
     )
-    assert tuple_err.return_type == types.Bottom
-    assert tuple_const_err.return_type == types.Bottom
+    assert tuple_err.return_type.is_equal(types.Bottom)
+    assert tuple_const_err.return_type.is_equal(types.Bottom)
     assert list_infer.return_type.is_subseteq(types.Int)
     assert list_slice.return_type.is_subseteq(types.List[types.Int])
-    assert unknown.return_type == types.Any
+    assert unknown.return_type.is_equal(types.Any)

--- a/test/interp/test_select.py
+++ b/test/interp/test_select.py
@@ -16,10 +16,7 @@ from kirin.worklist import WorkList
 @dataclass(init=False)
 class DummyInterpreter(ForwardExtra[EmptyLattice, None]):
     keys = ["test_interp", "main", "empty"]
-
-    @classmethod
-    def bottom_value(cls) -> EmptyLattice:
-        return EmptyLattice()
+    lattice = EmptyLattice
 
     @classmethod
     def default_worklist(cls) -> WorkList:


### PR DESCRIPTION
this PR simplifies a few APIs used for lattice. Interpreters are not longer dataclass - it turns out most of the case we need to define somewhat `__init__` for different interpreter anyways. 