### PR TITLE
rm empty MethodTable

### DIFF
--- a/src/kirin/analysis/const/prop.py
+++ b/src/kirin/analysis/const/prop.py
@@ -13,7 +13,7 @@ class ExtraFrameInfo:
 
 
 class Propagate(ForwardExtra[JointResult, ExtraFrameInfo]):
-    keys = ["constprop", "empty"]
+    keys = ["constprop"]
     lattice = JointResult
 
     def __init__(

--- a/src/kirin/analysis/typeinfer.py
+++ b/src/kirin/analysis/typeinfer.py
@@ -7,7 +7,7 @@ from kirin.analysis.forward import Forward
 
 
 class TypeInference(Forward[types.TypeAttribute]):
-    keys = ["typeinfer", "empty"]
+    keys = ["typeinfer"]
     lattice = types.TypeAttribute
 
     def build_signature(self, stmt: Statement, args: tuple):

--- a/src/kirin/interp/__init__.py
+++ b/src/kirin/interp/__init__.py
@@ -10,7 +10,7 @@ from kirin.interp.value import (
     Successor as Successor,
     ReturnValue as ReturnValue,
 )
-from kirin.interp.dialect import EmptyTable as EmptyTable, MethodTable as MethodTable
+from kirin.interp.dialect import MethodTable as MethodTable
 from kirin.interp.abstract import (
     AbstractFrame as AbstractFrame,
     AbstractInterpreter as AbstractInterpreter,

--- a/src/kirin/interp/concrete.py
+++ b/src/kirin/interp/concrete.py
@@ -9,7 +9,7 @@ from kirin.interp.value import Err, NoReturn, Successor, ReturnValue
 
 
 class Interpreter(BaseInterpreter[Frame[Any], Any]):
-    keys = ["main", "empty"]
+    keys = ["main"]
 
     def __init__(
         self,

--- a/src/kirin/interp/dialect.py
+++ b/src/kirin/interp/dialect.py
@@ -29,8 +29,3 @@ class MethodTable(ABC):
             if isinstance(value, ImplDef):
                 for sig in value.signature:
                     cls.table[sig] = value.impl
-
-
-@dataclass
-class EmptyTable(MethodTable):
-    pass

--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -29,11 +29,9 @@ class Dialect:
     codegen: dict[str, DialectEmit] = field(default_factory=dict, init=True)
 
     def __post_init__(self) -> None:
-        from kirin.interp.dialect import EmptyTable
         from kirin.lowering.dialect import NoSpecialLowering
 
         self.lowering["default"] = NoSpecialLowering()
-        self.interps["empty"] = EmptyTable()
 
     def __repr__(self) -> str:
         stmts = ", ".join([stmt.__name__ for stmt in self.stmts])


### PR DESCRIPTION
this is not needed because fallbacks are implemented within each interpreter class now.

NOTE: we still keep the selections keys because they still have the first come first register so certain dialect can supercede the inner implementation.