### PR TITLE
revise prelude dialect groups

### DIFF
--- a/src/kirin/dialects/ilist/__init__.py
+++ b/src/kirin/dialects/ilist/__init__.py
@@ -21,5 +21,6 @@ from .stmts import (
     ForEach as ForEach,
     IListType as IListType,
 )
+from .passes import IListDesugar as IListDesugar
 from .runtime import IList as IList
 from ._dialect import dialect as dialect

--- a/src/kirin/dialects/ilist/passes.py
+++ b/src/kirin/dialects/ilist/passes.py
@@ -1,0 +1,32 @@
+from kirin.ir import Method, types
+from kirin.rewrite import Walk, Fixpoint
+from kirin.passes.abc import Pass
+from kirin.rewrite.result import RewriteResult
+from kirin.dialects.ilist.rewrite import List2IList
+
+
+class IListDesugar(Pass):
+    """This pass desugars the Python list dialect
+    to the immutable list dialect by rewriting all
+    constant `list` type into `IList` type.
+    """
+
+    def unsafe_run(self, mt: Method) -> RewriteResult:
+        for arg in mt.args:
+            _check_list(arg.type, arg.type)
+        return Fixpoint(Walk(List2IList())).rewrite(mt.code)
+
+
+def _check_list(total: types.TypeAttribute, type_: types.TypeAttribute):
+    if isinstance(type_, types.Generic):
+        _check_list(total, type_.body)
+        for var in type_.vars:
+            _check_list(total, var)
+        if type_.vararg:
+            _check_list(total, type_.vararg.typ)
+    elif isinstance(type_, types.PyClass):
+        if issubclass(type_.typ, list):
+            raise TypeError(
+                f"Invalid type {total} for this kernel, use IList instead of {type_}."
+            )
+    return

--- a/src/kirin/dialects/ilist/rewrite/list.py
+++ b/src/kirin/dialects/ilist/rewrite/list.py
@@ -19,10 +19,15 @@ class List2IList(RewriteRule):
         return RewriteResult(has_done_something=has_done_something)
 
     def _rewrite_SSAValue_type(self, value: ir.SSAValue):
-        if value.type.is_subseteq(ir.types.List):
-            if isinstance(value.type, ir.types.Generic):
-                value.type = IListType[value.type.vars[0], ir.types.Any]
-            else:
-                value.type = IListType[ir.types.Any, ir.types.Any]
+        # NOTE: cannot use issubseteq here because type can be Bottom
+        if isinstance(value.type, ir.types.Generic) and issubclass(
+            value.type.body.typ, list
+        ):
+            value.type = IListType[value.type.vars[0], ir.types.Any]
+            return True
+        elif isinstance(value.type, ir.types.PyClass) and issubclass(
+            value.type.typ, list
+        ):
+            value.type = IListType[ir.types.Any, ir.types.Any]
             return True
         return False

--- a/src/kirin/dialects/ilist/runtime.py
+++ b/src/kirin/dialects/ilist/runtime.py
@@ -40,9 +40,17 @@ class IList(Generic[T, L]):
         return f"IList({self.data})"
 
     def __iter__(self):
-        raise NotImplementedError("Cannot use IList outside kernel.")
+        return iter(self.data)
 
-    def __getitem__(self, index: int) -> T:
+    @overload
+    def __getitem__(self, index: slice) -> "IList[T, Any]": ...
+
+    @overload
+    def __getitem__(self, index: int) -> T: ...
+
+    def __getitem__(self, index: int | slice) -> T | "IList[T, Any]":
+        if isinstance(index, slice):
+            return IList(self.data[index])
         return self.data[index]
 
     def __eq__(self, value: object) -> bool:

--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -169,6 +169,9 @@ class PyClass(TypeAttribute, typing.Generic[PyClassType], metaclass=PyClassMeta)
     def __hash__(self) -> int:
         return hash((PyClass, self.typ))
 
+    def __repr__(self) -> str:
+        return self.typ.__name__
+
     def print_impl(self, printer: Printer) -> None:
         printer.plain_print("!py.", self.typ.__name__)
 
@@ -388,6 +391,12 @@ class Generic(TypeAttribute, typing.Generic[PyClassType]):
 
     def __hash__(self) -> int:
         return hash((Generic, self.body, self.vars, self.vararg))
+
+    def __repr__(self) -> str:
+        if self.vararg is None:
+            return f"{self.body}[{', '.join(map(repr, self.vars))}]"
+        else:
+            return f"{self.body}[{', '.join(map(repr, self.vars))}, {self.vararg}, ...]"
 
     def print_impl(self, printer: Printer) -> None:
         printer.print(self.body)

--- a/test/analysis/dataflow/test_constprop.py
+++ b/test/analysis/dataflow/test_constprop.py
@@ -3,7 +3,7 @@ from kirin.ir import types
 from kirin.decl import info, statement
 from kirin.prelude import basic_no_opt
 from kirin.analysis import const
-from kirin.dialects import py
+from kirin.dialects import ilist
 
 
 class TestLattice:
@@ -279,10 +279,9 @@ def test_interprocedure_true_branch():
 
 def test_non_pure_recursion():
     @basic_no_opt
-    def for_loop_append(cntr: int, x: list, n_range: int):
+    def for_loop_append(cntr: int, x: ilist.IList, n_range: int):
         if cntr < n_range:
-            py.Append(x, cntr)  # type: ignore
-            for_loop_append(cntr + 1, x, n_range)
+            for_loop_append(cntr + 1, x + [cntr], n_range)
 
         return x
 

--- a/test/dialects/pystmts/test_coll_add.py
+++ b/test/dialects/pystmts/test_coll_add.py
@@ -1,5 +1,6 @@
 from kirin.ir import types
 from kirin.prelude import basic
+from kirin.dialects.ilist import IList, IListType
 
 
 @basic(typeinfer=True)
@@ -8,10 +9,10 @@ def tuple_new(x: int, xs: tuple):
 
 
 @basic(typeinfer=True)
-def list_new(x: int, xs: list):
+def list_new(x: int, xs: IList):
     return xs + [1, x]
 
 
 def test_tuple_add():
     assert tuple_new.return_type.is_subseteq(types.Tuple)
-    assert list_new.return_type.is_subseteq(types.List)
+    assert list_new.return_type.is_subseteq(IListType)

--- a/test/dialects/pystmts/test_getitem.py
+++ b/test/dialects/pystmts/test_getitem.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from kirin.ir import types
 from kirin.prelude import basic
+from kirin.dialects.ilist import IList, IListType
 
 
 @basic(typeinfer=True)
@@ -43,12 +46,12 @@ def tuple_const_err(xs: tuple[int, float, str]):
 
 
 @basic(typeinfer=True)
-def list_infer(xs: list[int], i: int):
+def list_infer(xs: IList[int, Any], i: int):
     return xs[i]
 
 
 @basic(typeinfer=True)
-def list_slice(xs: list[int], i: slice):
+def list_slice(xs: IList[int, Any], i: slice):
     return xs[i]
 
 
@@ -73,5 +76,5 @@ def test_getitem_typeinfer():
     assert tuple_err.return_type.is_equal(types.Bottom)
     assert tuple_const_err.return_type.is_equal(types.Bottom)
     assert list_infer.return_type.is_subseteq(types.Int)
-    assert list_slice.return_type.is_subseteq(types.List[types.Int])
+    assert list_slice.return_type.is_subseteq(IListType[types.Int])
     assert unknown.return_type.is_equal(types.Any)

--- a/test/program/py/test_list_append.py
+++ b/test/program/py/test_list_append.py
@@ -1,11 +1,11 @@
 # type: ignore
-from kirin.prelude import basic
+from kirin.prelude import python_no_opt
 from kirin.dialects import py
 
 
 def test_list_append():
 
-    @basic
+    @python_no_opt
     def test_append():
         x = []
         py.Append(x, 1)
@@ -20,7 +20,7 @@ def test_list_append():
 
 
 def test_recursive_append():
-    @basic
+    @python_no_opt
     def for_loop_append(cntr: int, x: list, n_range: int):
         if cntr < n_range:
             py.Append(x, cntr)

--- a/test/program/py/test_signature.py
+++ b/test/program/py/test_signature.py
@@ -1,9 +1,12 @@
+from typing import Any
+
 from kirin import types
 from kirin.prelude import basic
+from kirin.dialects.ilist import IList, IListType
 
 
 @basic
-def complicated_type(x: list[tuple[float, float, list[float]]]):
+def complicated_type(x: IList[tuple[float, float, IList[float, Any]], Any]):
     return x
 
 
@@ -11,5 +14,7 @@ def test_complicated_type():
     typ = complicated_type.arg_types[0]
     assert isinstance(typ, types.Generic)
     assert typ.is_subseteq(
-        types.List[types.Tuple[types.Float, types.Float, types.List[types.Float]]]
+        IListType[
+            types.Tuple[types.Float, types.Float, IListType[types.Float]], types.Any
+        ]
     )


### PR DESCRIPTION
this PR revise the prelude dialect groups as following:

`basic` and `basic_no_opt` are the basic language with immutable list and anything that is common in eDSLs in the future.
`python_basic` and `python_no_opt` are the exact python language with mutable list and anything that is Python oriented in the future.

the main issue here is to have a separation where those hard to compile but easy to interpret Python features should go.