### PR TITLE
remove eval_stmt add run_stmt_fallback

### DIFF
--- a/src/kirin/analysis/const/prop.py
+++ b/src/kirin/analysis/const/prop.py
@@ -48,7 +48,7 @@ class Propagate(ForwardExtra[JointResult, ExtraFrameInfo]):
         try:
             _frame = self.interp.new_frame(frame.code)
             _frame.set_values(stmt.args, tuple(x.data for x in values))
-            value = self.interp.eval_stmt(_frame, stmt)
+            value = self.interp.run_stmt(_frame, stmt)
             if isinstance(value, tuple):
                 return tuple(JointResult(Value(each), Pure()) for each in value)
             elif isinstance(value, interp.ReturnValue):
@@ -64,7 +64,7 @@ class Propagate(ForwardExtra[JointResult, ExtraFrameInfo]):
             pass
         return (self.bottom,)
 
-    def eval_stmt(
+    def run_stmt(
         self, frame: ForwardFrame[JointResult, ExtraFrameInfo], stmt: ir.Statement
     ) -> interp.StatementResult[JointResult]:
         if stmt.has_trait(ir.ConstantLike):

--- a/src/kirin/analysis/typeinfer/analysis.py
+++ b/src/kirin/analysis/typeinfer/analysis.py
@@ -30,13 +30,9 @@ class TypeInference(Forward[types.TypeAttribute]):
             return value.body
         return value
 
-    def eval_stmt(
+    def run_stmt_fallback(
         self, frame: ForwardFrame[types.TypeAttribute, None], stmt: ir.Statement
-    ) -> interp.StatementResult[types.TypeAttribute]:
-        method = self.lookup_registry(frame, stmt)
-        if method is not None:
-            return method(self, frame, stmt)
-
+    ) -> tuple[types.TypeAttribute, ...] | interp.SpecialResult[types.TypeAttribute]:
         resolve = TypeResolution()
         for arg, value in zip(stmt.args, frame.get_values(stmt.args)):
             resolve.solve(arg.type, value)


### PR DESCRIPTION
We have `eval_stmt` and `run_stmt` which has been two confusing APIs. The original intention was to separate the stage when registering the source info (which we don't have yet), and when to actually lookup the registery. I think this is not necessary now, to change how to update the source info just overload `run_stmt` otherwise update lookup behaviour with `lookup_registry` or define fallback via `run_stmt_fallback`

cc: @kaihsin 