### PR TITLE
add get_typed to interp.Frame

### DIFF
--- a/src/kirin/interp/frame.py
+++ b/src/kirin/interp/frame.py
@@ -80,10 +80,12 @@ class Frame(FrameABC[ValueType]):
                 and will be converted to an [`interp.Err`][kirin.interp.Err] in the interpretation
                 results.
         """
-        if (value := self.entries.get(key)) is not None:
-            return value
+        err = InterpreterError(f"SSAValue {key} not found")
+        value = self.entries.get(key, err)
+        if isinstance(value, InterpreterError):
+            raise err
         else:
-            raise InterpreterError(f"SSAValue {key} not found")
+            return value
 
     ExpectedType = TypeVar("ExpectedType")
 


### PR DESCRIPTION
allow better error message when implementing the method table of an interpreter.

changing the error from `KeyError` to `InterpreterError` so you can get a stacktrace at where the statement produces the undefined error - I think it's possible due to users' code actually having this error so it doesn't makes sense to terminate the interpreter program right away but instead should return the result as error.

cc: @weinbe58 @kaihsin 