### PR TITLE
add `Binding` object in lowering to enable special type hint binding

### DIFF
--- a/src/kirin/lowering/__init__.py
+++ b/src/kirin/lowering/__init__.py
@@ -3,4 +3,5 @@ from kirin.lowering.frame import Frame as Frame
 from kirin.lowering.state import LoweringState as LoweringState
 from kirin.lowering.result import Result as Result
 from kirin.lowering.stream import StmtStream as StmtStream
+from kirin.lowering.binding import wraps as wraps
 from kirin.lowering.dialect import FromPythonAST as FromPythonAST

--- a/src/kirin/lowering/binding.py
+++ b/src/kirin/lowering/binding.py
@@ -1,0 +1,65 @@
+from typing import TYPE_CHECKING, Generic, TypeVar, Callable, ParamSpec
+from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from kirin.ir.nodes.stmt import Statement
+
+Params = ParamSpec("Params")
+RetType = TypeVar("RetType")
+
+
+@dataclass(frozen=True)
+class Binding(Generic[Params, RetType]):
+    parent: type["Statement"]
+
+    def __call__(self, *args: Params.args, **kwargs: Params.kwargs) -> RetType:
+        raise NotImplementedError(
+            f"Binding of {self.parent.name} can \
+            only be called from a kernel"
+        )
+
+
+def wraps(parent: type["Statement"]):
+    """Wraps a [`Statement`][kirin.ir.nodes.stmt.Statement] to a `Binding` object
+    which will be special cased in the lowering process.
+
+    This is useful for providing type hints by faking the call signature of a
+    [`Statement`][kirin.ir.nodes.stmt.Statement].
+
+    ## Example
+
+    Directly writing a function with the statement will let Python linter think
+    you intend to call the constructor of the statement class. However, given the
+    context of a kernel, our intention is to actually "call" the statement, e.g
+    the following will produce type errors with pyright or mypy:
+
+    ```python
+    from kirin.dialects import math
+    from kirin.prelude import basic_no_opt
+
+    @basic_no_opt
+    def main(x: float):
+        return math.sin(x) # this is a statement, not a function
+    ```
+
+    the `@lowering.wraps` decorator allows us to provide a type hint for the
+    statement, e.g:
+
+    ```python
+    from kirin import lowering
+
+    @lowering.wraps(math.sin)
+    def sin(value: float) -> float: ...
+
+    @basic_no_opt
+    def main(x: float):
+        return sin(x) # linter now thinks this is a function
+
+    sin(1.0) # this will raise a NotImplementedError("Binding of sin can only be called from a kernel")
+    ```
+    """
+
+    def wrapper(func: Callable[Params, RetType]) -> Binding[Params, RetType]:
+        return Binding(parent)
+
+    return wrapper

--- a/src/kirin/lowering/state.py
+++ b/src/kirin/lowering/state.py
@@ -9,6 +9,7 @@ from kirin.source import SourceInfo
 from kirin.exceptions import DialectLoweringError
 from kirin.lowering.frame import Frame
 from kirin.lowering.result import Result
+from kirin.lowering.binding import Binding
 from kirin.lowering.dialect import FromPythonAST
 
 if TYPE_CHECKING:
@@ -152,6 +153,9 @@ class LoweringState(ast.NodeVisitor):
             return self.__lower_Call_local(node)
 
         global_callee = global_callee_result.unwrap()
+        if isinstance(global_callee, Binding):
+            global_callee = global_callee.parent
+
         if isinstance(global_callee, Method):
             if "Call_global_method" in self.registry:
                 return self.registry["Call_global_method"].lower_Call_global_method(

--- a/test/lowering/test_binding.py
+++ b/test/lowering/test_binding.py
@@ -1,0 +1,17 @@
+from kirin.prelude import basic_no_opt
+from kirin.dialects import math
+from kirin.lowering.binding import wraps
+
+
+@wraps(math.sin)
+def sin(value: float) -> float: ...
+
+
+@basic_no_opt
+def main(x: float):
+    return sin(x)
+
+
+def test_binding():
+    stmt = main.callable_region.blocks[0].stmts.at(0)
+    assert isinstance(stmt, math.sin)


### PR DESCRIPTION
Directly writing a function with the statement will let Python linter think
you intend to call the constructor of the statement class. However, given the
context of a kernel, our intention is to actually "call" the statement, e.g
the following will produce type errors with pyright or mypy:

```python
from kirin.dialects import math
from kirin.prelude import basic_no_opt

@basic_no_opt
def main(x: float):
    return math.sin(x) # this is a statement, not a function
```

the `@lowering.wraps` decorator allows us to provide a type hint for the
statement, e.g:

```python
from kirin import lowering

@lowering.wraps(math.sin)
def sin(value: float) -> float: ...

@basic_no_opt
def main(x: float):
    return sin(x) # linter now thinks this is a function

sin(1.0) # this will raise a NotImplementedError("Binding of sin can only be called from a kernel")
```

this PR adds a backdoor for lowering to treat the binding `sin` (of type `Binding`) above in the same effect as directly calling the statement (`math.sin` in first example).

cc: @kaihsin prob need to update the auto-gen script later, I'm gonna use the manual version for bloqade-qasm first.