### PR TITLE
implement griffe extension + try it on kirin builtin dialects

### DIFF
--- a/docs/dialects/cf.md
+++ b/docs/dialects/cf.md
@@ -2,3 +2,8 @@
     This page is under construction. The content may be incomplete or incorrect. Submit an issue
     on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
     contribute.
+
+
+::: kirin.dialects.cf.stmts
+    options:
+        show_if_no_docstring: true

--- a/docs/dialects/func.md
+++ b/docs/dialects/func.md
@@ -2,3 +2,7 @@
     This page is under construction. The content may be incomplete or incorrect. Submit an issue
     on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
     contribute.
+
+::: kirin.dialects.func.stmts
+    options:
+        show_if_no_docstring: true

--- a/docs/dialects/ilist.md
+++ b/docs/dialects/ilist.md
@@ -2,3 +2,8 @@
     This page is under construction. The content may be incomplete or incorrect. Submit an issue
     on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
     contribute.
+
+
+::: kirin.dialects.ilist.stmts
+    options:
+        show_if_no_docstring: true

--- a/docs/dialects/python/core.md
+++ b/docs/dialects/python/core.md
@@ -1,0 +1,95 @@
+!!! warning
+    This page is under construction. The content may be incomplete or incorrect. Submit an issue
+    on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
+    contribute.
+
+# Core Python Dialects
+
+This page contains the core Python dialects that are used most frequently when designing an
+embedded DSL in Python.
+
+## Reference
+
+### Base
+
+::: kirin.dialects.py.base
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### Constant
+
+::: kirin.dialects.py.constant
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### UnaryOp
+
+::: kirin.dialects.py.unary.stmts
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+
+### BinOp
+
+::: kirin.dialects.py.binop.stmts
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### Assertion
+
+::: kirin.dialects.py.assertion
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### Assignment
+
+::: kirin.dialects.py.assign
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+
+### Unpack
+
+::: kirin.dialects.py.unpack
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+
+### Boolean Operation
+
+::: kirin.dialects.py.boolop
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### Comparison
+
+::: kirin.dialects.py.cmp.stmts
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true

--- a/docs/dialects/python/data.md
+++ b/docs/dialects/python/data.md
@@ -1,0 +1,32 @@
+!!! warning
+    This page is under construction. The content may be incomplete or incorrect. Submit an issue
+    on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
+    contribute.
+
+# Dialects that brings in common Python data types
+
+This page provides a reference for dialects that bring in semantics for common Python data types.
+
+!!! note
+    While it is worth noting that using Python semantics can be very convenient, it is also important to remember that the Python semantics are not designed for compilation. Therefore, it is important to be aware of the limitations of using Python semantics in a compilation context especially when it comes to data types.
+    An example of this is the `list` data type in Python which is a dynamic mutable array. When the low-level code is not expecting a dynamic mutable array, it can lead to extra complexity for compilation. An immutable array or a fixed-size array can be a better choice in such cases (see `ilist` dialect).
+
+## References
+
+### Tuple
+
+::: kirin.dialects.py.tuple
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### List
+
+::: kirin.dialects.py.list
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true

--- a/docs/dialects/python/index.md
+++ b/docs/dialects/python/index.md
@@ -1,0 +1,10 @@
+!!! warning
+    This page is under construction. The content may be incomplete or incorrect. Submit an issue
+    on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
+    contribute.
+
+# Python Dialects
+
+Kirin provides a set of dialects that represents fractions of Python semantics. We will describe
+each dialect in this page. The general design principle of these dialects is to provide a composable
+set of Python semantics that can be used to build different embedded DSLs inside Python.

--- a/docs/dialects/python/sfunc.md
+++ b/docs/dialects/python/sfunc.md
@@ -1,0 +1,61 @@
+!!! warning
+    This page is under construction. The content may be incomplete or incorrect. Submit an issue
+    on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
+    contribute.
+
+# Dialects for special Python functions
+
+There are some special built-in Python functions that does not necessarily provide new data types when
+using them as Kirin dialects.
+
+For example, the `py.range` dialect may not use a Python `range` type,
+the actual type can be decided by another dialect that implements the type inference method for [`Range`][kirin.dialects.py.Range] statement, e.g `ilist` dialect provides an `IList` implementation for `Range` statement.
+
+The reason for this is that in many cases, eDSLs are not interested in the actual data type of the result, but rather the semantics of the operation. For `ilist` dialect, the `Range` statement is just a syntax sugar for creating a list of integers. The compiler will decide what the actual implementation (such as the memory layout) of the list should be.
+
+# References
+
+## Iterable
+
+::: kirin.dialects.py.iterable
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+## Len
+
+::: kirin.dialects.py.len
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+## Range
+
+::: kirin.dialects.py.range
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+## Slice
+
+::: kirin.dialects.py.slice
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+## Built-in Function
+
+::: kirin.dialects.py.builtin
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true

--- a/docs/dialects/python/sugar.md
+++ b/docs/dialects/python/sugar.md
@@ -1,0 +1,30 @@
+!!! warning
+    This page is under construction. The content may be incomplete or incorrect. Submit an issue
+    on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
+    contribute.
+
+# Dialects for Python Syntax Sugar
+
+This page contains the dialects designed to represent Python syntax sugar. They provide an implementation
+of lowering transform from the corresponding Python AST to the dialects' statements. All the statements are
+typed `Any` thus one can always use a custom rewrite pass after type inference to support the desired syntax sugar.
+
+## Reference
+
+### Indexing
+
+::: kirin.dialects.py.indexing
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true
+
+### Attribute
+
+::: kirin.dialects.py.attr
+    options:
+        filters:
+        - "!statement"
+        show_root_heading: true
+        show_if_no_docstring: true

--- a/docs/dialects/scf.md
+++ b/docs/dialects/scf.md
@@ -2,3 +2,11 @@
     This page is under construction. The content may be incomplete or incorrect. Submit an issue
     on [GitHub](https://github.com/QuEraComputing/kirin/issues/new) if you need help or want to
     contribute.
+
+# SCF Dialects
+
+# Reference
+
+::: kirin.dialects.scf.stmts
+    options:
+        show_if_no_docstring: true

--- a/docs/interp.md
+++ b/docs/interp.md
@@ -98,7 +98,7 @@ class Assert(Statement):
     message: SSAValue = info.argument(String)
 ```
 
-When interpreting an `Assert` statement, we need to check the condition and raise an error if it is false, this can be either returning the [`interp.Err`][kirin.interp.Err] object:
+When interpreting an `Assert` statement, we need to check the condition and raise an error if it is false:
 
 ```python
 @dialect.register
@@ -110,9 +110,9 @@ class CfMethods(MethodTable):
             return ()
 
         if stmt.message:
-            return Err(AssertionError(frame.get(stmt.message)), interp.state.frames)
+            raise interp.WrapException(AssertionError(frame.get(stmt.message)))
         else:
-            return Err(AssertionError(), interp.state.frames)
+            raise interp.WrapException(AssertionError("Assertion failed"))
 ```
 
 or raising an [`InterpreterError`][kirin.exceptions.InterpreterError]:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,9 +15,15 @@ nav:
       - Interpretation: interp.md
       - Analysis: analysis.md
       - Dialects:
-        - Python: dialects/python.md
+        - Python:
+          - dialects/python/index.md
+          - Core: dialects/python/core.md
+          - Data: dialects/python/data.md
+          - Syntax Sugar: dialects/python/sugar.md
+          - Special Functions: dialects/python/sfunc.md
         - Function: dialects/func.md
         - Control Flow: dialects/cf.md
+        - Structural Control Flow: dialects/scf.md
         - Immutable List: dialects/ilist.md
       - Compiler 101: 101.md
       - Comparison: comparison.md
@@ -110,6 +116,7 @@ plugins:
             merge_init_into_class: true
             extensions:
               - griffe_inherited_docstrings
+              - scripts/griffe_ext.py:KirinExtension
             show_inheritance_diagram: true
             show_signature_annotations: true
             show_symbol_type_heading: true

--- a/scripts/griffe_ext.py
+++ b/scripts/griffe_ext.py
@@ -1,0 +1,258 @@
+# adopted from mkdocstrings/griffe-pydantic/
+# from __future__ import annotations
+
+from typing import Any, cast
+
+import griffe
+
+logger = griffe.get_logger(__name__)
+
+
+def inherits_statement(cls: griffe.Class) -> bool:
+    """Tell whether a class inherits from kirin.ir.Statement."""
+    for base in cls.bases:
+        if isinstance(base, (griffe.ExprName, griffe.Expr)):
+            base = base.canonical_path  # noqa: PLW2901
+        if base == "kirin.ir.Statement":
+            return True
+    return any(inherits_statement(parent_cls) for parent_cls in cls.mro())
+
+
+def has_default(value: griffe.ExprCall) -> bool:
+    return (
+        len(value.arguments) >= 1
+        and not isinstance(value.arguments[0], griffe.ExprKeyword)
+        and value.arguments[0] != "..."
+    )  # handle field(...), i.e. no default
+
+
+def process_attribute(
+    attr: griffe.Attribute, cls: griffe.Class, *, processed: set[str]
+) -> None:
+    """Handle ir.Statement attributes."""
+    if attr.canonical_path in processed:
+        return
+    processed.add(attr.canonical_path)
+
+    kwargs = {}
+    if isinstance(attr.value, griffe.ExprCall):
+        kwargs = {
+            argument.name: argument.value
+            for argument in attr.value.arguments
+            if isinstance(argument, griffe.ExprKeyword)
+        }
+        field_descriptor = attr.value.function.canonical_path
+        kwargs = _descriptor_args(attr.value)
+        if field_descriptor == "kirin.decl.info.argument":
+            attr.labels = {"kirin-argument"}
+            if "kw_only" in kwargs and kwargs["kw_only"] == "True":
+                attr.labels.add("kw-only")
+        elif field_descriptor == "kirin.decl.info.attribute":
+            if "property" in kwargs and kwargs["property"] == "True":
+                attr.labels = {"kirin-property"}
+            else:
+                attr.labels = {"kirin-attribute"}
+            attr.labels.add("kw-only")
+        elif field_descriptor == "kirin.decl.info.result":
+            attr.labels = {"kirin-result"}
+        elif field_descriptor == "kirin.decl.info.region":
+            attr.labels = {"kirin-region", "kw-only"}
+        elif field_descriptor == "kirin.decl.info.block":
+            attr.labels = {"kirin-block", "kw-only"}
+    elif attr.value is not None:
+        # logger.warning(f"Unhandled attribute value: {attr.value!r}")
+        return  # wrong declaration
+    elif attr.value is None and _is_annotation_SSAValue(attr.annotation):
+        attr.labels = {"kirin-argument"}
+
+
+def _is_annotation_SSAValue(annotation: str | griffe.Expr | None):
+    if annotation is None:
+        return False
+    if isinstance(annotation, str):
+        return annotation in ("ir.SSAValue", "SSAValue")
+    if isinstance(annotation, griffe.Expr):
+        return annotation.canonical_path in "kirin.ir.ssa.SSAValue"
+
+
+def _descriptor_args(field: griffe.ExprCall) -> dict[str, Any]:
+    kwargs = {
+        argument.name: argument.value
+        for argument in field.arguments
+        if isinstance(argument, griffe.ExprKeyword)
+    }
+    if has_default(field):
+        kwargs["type"] = field.arguments[0]
+    return kwargs
+
+
+def process_class(cls: griffe.Class, *, processed: set[str]) -> None:
+    """Handle ir.Statement classes."""
+    if cls.canonical_path in processed:
+        return
+
+    if not inherits_statement(cls):
+        return
+
+    processed.add(cls.canonical_path)
+    cls.labels = {"krin-statement"}
+    for member in cls.all_members.values():
+        if isinstance(member, griffe.Attribute):
+            process_attribute(member, cls, processed=processed)
+        # TODO: process inherited methods?
+
+    if "__init__" not in cls.members:
+        _statement_init(cls)
+
+
+def _statement_init_parameters(cls: griffe.Class) -> list[griffe.Parameter]:
+    params: list[griffe.Parameter] = []
+    for member in cls.members.values():
+        if member.is_attribute:
+            member = cast(griffe.Attribute, member)
+            if member.annotation is None:
+                continue
+
+            if isinstance(member.value, griffe.ExprCall):
+                kwargs = _descriptor_args(member.value)
+            else:
+                kwargs = {}
+
+            if "init" in kwargs and kwargs["init"] == "False":
+                continue
+
+            kind = (
+                griffe.ParameterKind.keyword_only
+                if "kw-only" in member.labels
+                else griffe.ParameterKind.positional_or_keyword
+            )
+
+            if "default_factory" in kwargs:
+                default_factory = kwargs["default_factory"]
+                if isinstance(default_factory, griffe.ExprLambda):
+                    default = default_factory.body
+                else:
+                    default = griffe.ExprCall(
+                        function=kwargs["default_factory"], arguments=[]
+                    )
+            else:
+                default = None
+
+            if "kirin-argument" in member.labels:
+                params.append(
+                    griffe.Parameter(
+                        member.name,
+                        annotation=member.annotation,
+                        kind=kind,
+                        default=default,
+                        docstring=member.docstring,
+                    )
+                )
+            elif (
+                "kirin-attribute" in member.labels
+                or "kirin-property" in member.labels
+                or "kirin-block" in member.labels
+                or "kirin-region" in member.labels
+            ):
+                params.append(
+                    griffe.Parameter(
+                        member.name,
+                        annotation=member.annotation,
+                        kind=griffe.ParameterKind.keyword_only,
+                        default=default,
+                        docstring=member.docstring,
+                    )
+                )
+    return params
+
+
+def _statement_init(cls: griffe.Class):
+    params = []
+    try:
+        mro = cls.mro()
+    except ValueError:
+        mro = ()
+    for parent in reversed(mro):
+        if inherits_statement(parent):
+            params.extend(_statement_init_parameters(parent))
+            cls.labels.add("kirin-statement")
+
+    if not inherits_statement(cls):
+        return
+
+    params.extend(_statement_init_parameters(cls))
+
+    init = griffe.Function(
+        "__init__",
+        lineno=0,
+        endlineno=0,
+        parent=cls,
+        parameters=griffe.Parameters(
+            griffe.Parameter(
+                name="self",
+                annotation=None,
+                kind=griffe.ParameterKind.positional_or_keyword,
+                default=None,
+                docstring=None,
+            ),
+            *_reorder_parameters(params),
+        ),
+        returns="None",
+    )
+    cls.set_member("__init__", init)
+
+
+# NOTE: copied from griffe/src/_griffe/extensions/dataclasses.py
+def _reorder_parameters(parameters: list[griffe.Parameter]) -> list[griffe.Parameter]:
+    # De-duplicate, overwriting previous parameters.
+    params_dict = {param.name: param for param in parameters}
+
+    # Re-order, putting positional-only in front and keyword-only at the end.
+    pos_only = []
+    pos_kw = []
+    kw_only = []
+    for param in params_dict.values():
+        if param.kind is griffe.ParameterKind.positional_only:
+            pos_only.append(param)
+        elif param.kind is griffe.ParameterKind.keyword_only:
+            kw_only.append(param)
+        else:
+            pos_kw.append(param)
+    return pos_only + pos_kw + kw_only
+
+
+def process_module(mod: griffe.Module, *, processed: set[str]):
+    if mod.canonical_path in processed:
+        return
+
+    processed.add(mod.canonical_path)
+    for cls in mod.classes.values():
+        if not cls.is_alias:
+            process_class(cls, processed=processed)
+
+    for submod in mod.modules.values():
+        if not submod.is_alias:
+            process_module(submod, processed=processed)
+
+
+class KirinExtension(griffe.Extension):
+
+    def __init__(self):
+        super().__init__()
+        self.in_statement: list[griffe.Class] = []
+        self.processed: set[str] = set()
+
+    def on_package_loaded(
+        self, *, pkg: griffe.Module, loader: griffe.GriffeLoader, **kwargs: Any
+    ) -> None:
+        process_module(pkg, processed=self.processed)
+
+
+# extensions = griffe.load_extensions(KirinExtension())
+# data = griffe.load("kirin", extensions=extensions)
+
+# obj = data["dialects.func.stmts.Function"]
+# print(obj.labels)
+# # print(obj.get_member("sym_name").labels)
+# # print(obj.get_member("body").labels)
+# # print(obj.get_member("sym_name").docstring.value)

--- a/src/kirin/dialects/__init__.py
+++ b/src/kirin/dialects/__init__.py
@@ -1,0 +1,14 @@
+"""Built-in dialects for Kirin.
+
+This module contains the built-in dialects for Kirin. Each dialect is an
+instance of the `Dialect` class. Each submodule contains a `dialect` variable
+that is an instance of the corresponding `Dialect` class.
+
+The modules can be directly used as dialects. For example, you can write
+
+```python
+from kirin.dialects import py, func
+```
+
+to import the Python and function dialects.
+"""

--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -44,6 +44,7 @@ class Function(Statement):
         }
     )
     sym_name: str = info.attribute(property=True)
+    """The symbol name of the function."""
     signature: Signature = info.attribute()
     body: Region = info.region(multi=True)
 

--- a/src/kirin/interp/frame.py
+++ b/src/kirin/interp/frame.py
@@ -114,9 +114,7 @@ class Frame(FrameABC[ValueType]):
             ValueType: The value.
 
         Raises:
-            InterpreterError: If the value is not found. This will be catched by the interpreter
-                and will be converted to an [`interp.Err`][kirin.interp.Err] in the interpretation
-                results.
+            InterpreterError: If the value is not found. This will be catched by the interpreter.
         """
         err = InterpreterError(f"SSAValue {key} not found")
         value = self.entries.get(key, err)
@@ -138,9 +136,7 @@ class Frame(FrameABC[ValueType]):
             ExpectedType: The value.
 
         Raises:
-            InterpreterError: If the value is not of the expected type. This will be catched
-                by the interpreter and will be converted to an [`interp.Err`][kirin.interp.Err]
-                in the interpretation results.
+            InterpreterError: If the value is not of the expected type.
         """
         value = self.get(key)
         if not isinstance(value, type_):

--- a/src/kirin/ir/nodes/__init__.py
+++ b/src/kirin/ir/nodes/__init__.py
@@ -1,3 +1,6 @@
+"""Definition of Kirin's Intermediate Representation (IR) nodes.
+"""
+
 from kirin.ir.nodes.base import IRNode as IRNode
 from kirin.ir.nodes.stmt import Statement as Statement
 from kirin.ir.nodes.block import Block as Block

--- a/src/kirin/ir/traits/__init__.py
+++ b/src/kirin/ir/traits/__init__.py
@@ -1,3 +1,14 @@
+"""Kirin IR Traits.
+
+This module defines the traits that can be used to define the behavior of
+Kirin IR nodes. The base trait is `StmtTrait`, which is a `dataclass` that
+implements the `__hash__` and `__eq__` methods.
+
+There are also some basic traits that are provided for convenience, such as
+`Pure`, `HasParent`, `ConstantLike`, `IsTerminator`, `NoTerminator`, and
+`IsolatedFromAbove`.
+"""
+
 from .abc import (
     StmtTrait as StmtTrait,
     RegionTrait as RegionTrait,

--- a/src/kirin/ir/traits/abc.py
+++ b/src/kirin/ir/traits/abc.py
@@ -22,6 +22,7 @@ GraphType = TypeVar("GraphType", bound="Graph[Block]")
 
 @dataclass(frozen=True)
 class RegionTrait(StmtTrait, Generic[GraphType]):
+    """A trait that indicates the properties of the statement's region."""
 
     @abstractmethod
     def get_graph(self, region: "Region") -> GraphType: ...
@@ -33,6 +34,7 @@ StatementType = TypeVar("StatementType", bound="Statement")
 
 @dataclass(frozen=True)
 class PythonLoweringTrait(StmtTrait, Generic[StatementType, ASTNode]):
+    """A trait that indicates that a statement can be lowered from Python AST."""
 
     @abstractmethod
     def lower(

--- a/src/kirin/ir/traits/basic.py
+++ b/src/kirin/ir/traits/basic.py
@@ -9,21 +9,35 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Pure(StmtTrait):
+    """A trait that indicates that a statement is pure, i.e., it has no side
+    effects.
+    """
+
     pass
 
 
 @dataclass(frozen=True)
 class ConstantLike(StmtTrait):
+    """A trait that indicates that a statement is constant-like, i.e., it
+    represents a constant value.
+    """
+
     pass
 
 
 @dataclass(frozen=True)
 class IsTerminator(StmtTrait):
+    """A trait that indicates that a statement is a terminator, i.e., it
+    terminates a block.
+    """
+
     pass
 
 
 @dataclass(frozen=True)
 class NoTerminator(StmtTrait):
+    """A trait that indicates that the region of a statement has no terminator."""
+
     pass
 
 
@@ -34,4 +48,8 @@ class IsolatedFromAbove(StmtTrait):
 
 @dataclass(frozen=True)
 class HasParent(StmtTrait):
+    """A trait that indicates that a statement has a parent
+    statement.
+    """
+
     parents: tuple[type["Statement"]]

--- a/src/kirin/ir/traits/callable.py
+++ b/src/kirin/ir/traits/callable.py
@@ -13,6 +13,10 @@ StmtType = TypeVar("StmtType", bound="Statement")
 
 @dataclass(frozen=True)
 class CallableStmtInterface(StmtTrait, Generic[StmtType]):
+    """A trait that indicates that a statement is a callable statement.
+
+    A callable statement is a statement that can be called as a function.
+    """
 
     @classmethod
     @abstractmethod
@@ -23,6 +27,9 @@ class CallableStmtInterface(StmtTrait, Generic[StmtType]):
 
 @dataclass(frozen=True)
 class HasSignature(StmtTrait, ABC):
+    """A trait that indicates that a statement has a function signature
+    attribute.
+    """
 
     @classmethod
     def get_signature(cls, stmt: "Statement"):

--- a/src/kirin/ir/traits/lowering/__init__.py
+++ b/src/kirin/ir/traits/lowering/__init__.py
@@ -1,0 +1,2 @@
+"""Lowering traits for the IR.
+"""

--- a/src/kirin/ir/traits/region/__init__.py
+++ b/src/kirin/ir/traits/region/__init__.py
@@ -1,0 +1,2 @@
+"""Builtin region traits.
+"""

--- a/src/kirin/ir/traits/region/ssacfg.py
+++ b/src/kirin/ir/traits/region/ssacfg.py
@@ -1,3 +1,9 @@
+"""SSACFG region trait.
+
+This module defines the SSACFGRegion trait, which is used to indicate that a
+region has an SSACFG graph.
+"""
+
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
 

--- a/src/kirin/ir/traits/symbol.py
+++ b/src/kirin/ir/traits/symbol.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class SymbolOpInterface(StmtTrait):
+    """A trait that indicates that a statement is a symbol operation.
+
+    A symbol operation is a statement that has a symbol name attribute.
+    """
 
     def get_sym_name(self, stmt: "Statement") -> "PyAttr[str]":
         sym_name: PyAttr[str] | None = stmt.get_attr_or_prop("sym_name")  # type: ignore

--- a/src/kirin/print/printer.py
+++ b/src/kirin/print/printer.py
@@ -1,5 +1,15 @@
 import io
-from typing import IO, TYPE_CHECKING, Any, Union, Literal, TypeVar, Callable, Iterable
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Union,
+    Literal,
+    TypeVar,
+    Callable,
+    Iterable,
+    Generator,
+)
 from contextlib import contextmanager
 from dataclasses import field, dataclass
 
@@ -242,7 +252,7 @@ class Printer:
         *,
         emit: Callable[[ValueType], None] | None = None,
         delim: str = ", ",
-    ):
+    ) -> None:
         """print a mapping of key-value pairs.
 
         Args:
@@ -274,7 +284,7 @@ class Printer:
         return result_width
 
     @contextmanager
-    def align(self, width: int):
+    def align(self, width: int) -> Generator[PrintState, Any, None]:
         """align the result column width, and restore it after the context.
 
         Args:
@@ -291,7 +301,9 @@ class Printer:
             self.state.result_width = old_width
 
     @contextmanager
-    def indent(self, increase: int = 2, mark: bool | None = None):
+    def indent(
+        self, increase: int = 2, mark: bool | None = None
+    ) -> Generator[PrintState, Any, None]:
         """increase the indentation level, and restore it after the context.
 
         Args:
@@ -313,11 +325,13 @@ class Printer:
                 self.state.indent_marks.pop()
 
     @contextmanager
-    def rich(self, style: str | None = None, highlight: bool = False):
+    def rich(
+        self, style: str | None = None, highlight: bool = False
+    ) -> Generator[PrintState, Any, None]:
         """set the rich style and highlight, and restore them after the context.
 
         Args:
-            style(str): style to use, default to None
+            style(str | None): style to use, default to None
             highlight(bool): whether to highlight the text, default to False
 
         Yields:
@@ -334,7 +348,7 @@ class Printer:
             self.state.rich_highlight = old_highlight
 
     @contextmanager
-    def string_io(self):
+    def string_io(self) -> Generator[io.StringIO, Any, None]:
         """Temporary string IO for capturing output.
 
         Yields:


### PR DESCRIPTION
This implements a griffe extension for Kirin so that we can correctly display the generated constructor of Kirin statements and mark which is `argument`, `region`, `block` in the field labels, e.g

<img width="706" alt="image" src="https://github.com/user-attachments/assets/15989f72-01e8-4ae7-a6b4-086efa8eb1d6" />

A follow up work is to actually move the extension into a package so that downstream packages can use it in combination with mkdocs.