### PR TITLE
fix loop body globals

### DIFF
--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -87,7 +87,10 @@ class Lowering(lowering.FromPythonAST):
 
         body_frame = state.push_frame(
             lowering.Frame.from_stmts(
-                node.body, state, capture_callback=new_block_arg_if_inside_loop
+                node.body,
+                state,
+                globals=state.current_frame.globals,
+                capture_callback=new_block_arg_if_inside_loop,
             )
         )
         loop_var = body_frame.curr_block.args.append_from(ir.types.Any)


### PR DESCRIPTION
making qasm2 qft example failing as following

```python
import math

from bloqade import qasm2
from kirin.dialects import cf, scf, lowering

@qasm2.kernel.discard(lowering.cf).add(scf)
def qft(n: int):
    qreg = qasm2.qreg(n)
    if n == 0:
        return

    qasm2.h(qreg[0])
    for i in range(1, n):
        qasm2.cu1(qreg[i], qreg[0], 2 * math.pi / 2**i)
    qft(n - 1)
```

forgot to forward the globals when lowering loop body.