### PR TITLE
add method similar to ir.Method

### DIFF
--- a/src/kirin/ir/method.py
+++ b/src/kirin/ir/method.py
@@ -102,3 +102,17 @@ class Method(Printable, typing.Generic[Param, RetType]):
             raise Exception(msg) from e
         self.verified = True
         return
+
+    def similar(self, dialects: typing.Optional["DialectGroup"] = None):
+        return Method(
+            self.mod,
+            self.py_func,
+            self.sym_name,
+            self.arg_names,
+            dialects or self.dialects,
+            self.code.from_stmt(self.code, regions=[self.callable_region.clone()]),
+            self.fields,
+            self.file,
+            self.inferred,
+            self.verified,
+        )


### PR DESCRIPTION
adding a `similar` method to create a similar `Method` but different dialect group. This is a bit ad hoc, but quite useful for building targets.

cc: @kaihsin 