### PR TITLE
allow walk to skip some nodes

### DIFF
--- a/src/kirin/dialects/ilist/runtime.py
+++ b/src/kirin/dialects/ilist/runtime.py
@@ -13,6 +13,9 @@ class IList(Generic[T, L]):
 
     data: Sequence[T]
 
+    def __hash__(self) -> int:
+        return id(self)  # do not hash the data
+
     def __len__(self) -> int:
         return len(self.data)
 

--- a/src/kirin/rewrite/__init__.py
+++ b/src/kirin/rewrite/__init__.py
@@ -1,3 +1,4 @@
+from .cse import CommonSubexpressionElimination as CommonSubexpressionElimination
 from .dce import DeadCodeElimination as DeadCodeElimination
 from .fold import ConstantFold as ConstantFold
 from .walk import Walk as Walk

--- a/src/kirin/rewrite/walk.py
+++ b/src/kirin/rewrite/walk.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from dataclasses import field, dataclass
 
 from kirin.ir import Block, Region, Statement
@@ -21,6 +22,7 @@ class Walk(RewriteRule):
 
     rule: RewriteRule
     worklist: WorkList[IRNode] = field(default_factory=WorkList)
+    skip: Callable[[IRNode], bool] = field(default=lambda _: False)
 
     # options
     reverse: bool = field(default=False)
@@ -44,6 +46,9 @@ class Walk(RewriteRule):
         return RewriteResult(has_done_something=has_done_something)
 
     def populate_worklist(self, node: IRNode) -> None:
+        if self.skip(node):
+            return
+
         if isinstance(node, Statement):
             self.populate_worklist_Statement(node)
         elif isinstance(node, Region):


### PR DESCRIPTION
this is useful for e.g inline pass to avoid inlining functions calls inside a scf.For which creates multiple basic blocks not allowed by the `scf.For` (loop unroll should be trigger before inlining)

polish constant fold evaluation to remove the `try ... catch`