### PR TITLE
fix repeat until success example

### DIFF
--- a/src/kirin/dialects/scf/__init__.py
+++ b/src/kirin/dialects/scf/__init__.py
@@ -11,6 +11,7 @@ This dialect depends on the following dialects:
 """
 
 from . import (
+    trim as trim,
     absint as absint,
     interp as interp,
     unroll as unroll,

--- a/src/kirin/dialects/scf/stmts.py
+++ b/src/kirin/dialects/scf/stmts.py
@@ -83,7 +83,11 @@ class IfElse(ir.Statement):
         printer.print(self.cond)
         printer.plain_print(" ")
         printer.print(self.then_body)
-        if self.else_body.blocks:
+        if self.else_body.blocks and not (
+            len(self.else_body.blocks[0].stmts) == 1
+            and isinstance(else_term := self.else_body.blocks[0].last_stmt, Yield)
+            and not else_term.values  # empty yield
+        ):
             printer.plain_print(" else ", style="keyword")
             printer.print(self.else_body)
 

--- a/src/kirin/dialects/scf/trim.py
+++ b/src/kirin/dialects/scf/trim.py
@@ -1,0 +1,36 @@
+from kirin import ir
+from kirin.rewrite.abc import RewriteRule
+from kirin.rewrite.result import RewriteResult
+
+from .stmts import For, Yield, IfElse
+
+
+class UnusedYield(RewriteRule):
+    """Trim unused results from `For` and `IfElse` statements."""
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, (For, IfElse)):
+            return RewriteResult()
+
+        any_unused = False
+        uses: list[int] = []
+        results: list[ir.ResultValue] = []
+        for idx, result in enumerate(node.results):
+            if result.uses:
+                uses.append(idx)
+                results.append(result)
+            else:
+                any_unused = True
+
+        if not any_unused:
+            return RewriteResult()
+
+        node._results = results
+        for region in node.regions:
+            for block in region.blocks:
+                if not isinstance(block.last_stmt, Yield):
+                    continue
+
+                block.last_stmt.args = [block.last_stmt.args[idx] for idx in uses]
+
+        return RewriteResult(has_done_something=True)

--- a/src/kirin/dialects/scf/unroll.py
+++ b/src/kirin/dialects/scf/unroll.py
@@ -84,6 +84,7 @@ class ForLoop(RewriteRule):
             # TODO: check this in validation
             if isinstance(terminator, Yield):
                 loop_vars = terminator.values
+                terminator.delete()
 
         for result, output in zip(node.results, loop_vars):
             result.replace_by(output)


### PR DESCRIPTION
This PR implements

- a trimming rewrite rule to remove redundant yield values from `scf` statements. 
- a fix of dead statement in loop unroll
- introduce `del` to `stmt.args` and `stmt.results` the use of `del` follows the same convention as a `Sequence`.