### PR TITLE
allow eagerly eval global attr

### DIFF
--- a/test/program/py/test_glob_pi.py
+++ b/test/program/py/test_glob_pi.py
@@ -1,0 +1,14 @@
+import math
+
+from kirin.prelude import basic_no_opt
+from kirin.dialects import py
+
+
+def test_math_pi():
+    @basic_no_opt
+    def main():
+        return math.pi
+
+    stmt = main.callable_region.blocks[0].stmts.at(0)
+    assert isinstance(stmt, py.Constant)
+    assert stmt.value == math.pi


### PR DESCRIPTION
I know this has been annoying. See the test for an example. I think this should be considered a bug, although it still worth discussion on how far do we allow eagerly evaluation on expressions involves global value access, e.g `glob[1]` does not make sense in this case?