### PR TITLE
fix a few bugs in pauli exp example

### DIFF
--- a/src/kirin/dialects/py/binop/typeinfer.py
+++ b/src/kirin/dialects/py/binop/typeinfer.py
@@ -38,7 +38,7 @@ class TypeInfer(interp.MethodTable):
         return (types.Int,)
 
     @interp.impl(stmts.Div)
-    def divf(self, *_):
+    def divf(self, typeinfer_, frame, stmt):
         return (types.Float,)
 
     @interp.impl(stmts.Mod, types.Float, types.Float)

--- a/src/kirin/dialects/py/indexing.py
+++ b/src/kirin/dialects/py/indexing.py
@@ -119,6 +119,8 @@ class TypeInfer(interp.MethodTable):
         # TODO: replace this when we can multiple dispatch
         if obj.is_subseteq(types.Tuple):
             return self.getitem_tuple(interp, stmt, obj, index)
+        elif obj.is_subseteq(types.String):
+            return (types.String,)
         else:
             return (types.Any,)
 
@@ -149,9 +151,11 @@ class TypeInfer(interp.MethodTable):
         index: types.TypeAttribute,
     ):
         if index_ := interp.maybe_const(stmt.index, int):
-            if obj.vararg and index_ >= len(obj.vars):
+            if obj.vararg and (index_ >= len(obj.vars) or -len(obj.vars) <= index_ < 0):
                 return (obj.vararg.typ,)
-            elif index_ < len(obj.vars):
+            elif obj.vars and (
+                0 <= index_ < len(obj.vars) or -len(obj.vars) <= index_ < 0
+            ):
                 return (obj.vars[index_],)
             else:
                 return (types.Bottom,)

--- a/src/kirin/dialects/scf/absint.py
+++ b/src/kirin/dialects/scf/absint.py
@@ -59,4 +59,6 @@ class Methods(interp.MethodTable):
         with interp_.state.new_frame(interp_.new_frame(stmt)) as body_frame:
             body_frame.entries.update(frame.entries)
             body_frame.set(body_block.args[0], frame.get(stmt.cond))
-            return interp_.run_ssacfg_region(body_frame, body)
+            ret = interp_.run_ssacfg_region(body_frame, body)
+            frame.entries.update(body_frame.entries)
+            return ret

--- a/src/kirin/dialects/scf/unroll.py
+++ b/src/kirin/dialects/scf/unroll.py
@@ -23,7 +23,7 @@ class PickIfElse(RewriteRule):
             return self.insert_body(node, node.else_body)
 
     def insert_body(self, node: IfElse, body: ir.Region):
-        body_block = body.clone().blocks[0]
+        body_block = body.blocks[0]
         body_block.args[0].replace_by(node.cond)
         block_stmt = body_block.first_stmt
         while block_stmt and not block_stmt.has_trait(ir.IsTerminator):

--- a/src/kirin/rewrite/getitem.py
+++ b/src/kirin/rewrite/getitem.py
@@ -21,7 +21,9 @@ class InlineGetItem(RewriteRule):
 
         stmt = node.obj.owner
         index = index_value.data
-        if isinstance(index, int) and 0 <= index < len(stmt.args):
+        if isinstance(index, int) and (
+            0 <= index < len(stmt.args) or -len(stmt.args) <= index < 0
+        ):
             node.result.replace_by(stmt.args[index])
             return RewriteResult(has_done_something=True)
         elif isinstance(index, slice):


### PR DESCRIPTION
The fix here is simple, just check the boundary more carefully and don't clone the region when flattening `IfElse` (it will be deleted anyways). To test with the fix, it was trigger by the following mwe.


```python
import math
from kirin.analysis import CFG, const
from kirin.passes import aggressive
from kirin.rewrite import Fixpoint, Chain, Walk, WrapConst, ConstantFold, DeadCodeElimination
from kirin.prelude import structural
from kirin.dialects import scf
from bloqade import qasm2
from bloqade.qasm2.passes import QASM2Fold

@qasm2.extended
def pauli_basis_change(x):
    qreg = qasm2.qreg(1)
    qubit = qreg[0]

    target = "XZ"
    if target == "ZX":
        qasm2.ry(qubit, math.pi / 2)
    elif target == "ZY":
        qasm2.ry(qubit, math.pi / 2)
    elif target == "XY":
        qasm2.ry(qubit, math.pi / 2)
    elif target == "XZ":
        qasm2.ry(qubit, math.pi / 2)
    elif target == "YX":
        qasm2.ry(qubit, math.pi / 2)


fold = QASM2Fold(qasm2.extended)
fold.fixpoint(pauli_basis_change)
# constprop = const.Propagate(qasm2.extended)
# frame, ret = constprop.run_analysis(pauli_basis_change)

# Fixpoint(Walk(WrapConst(frame))).rewrite(pauli_basis_change.code)
# Fixpoint(Walk(ConstantFold())).rewrite(pauli_basis_change.code)
# # Fixpoint(Walk(DeadCodeElimination())).rewrite(pauli_basis_change.code)
# Walk(scf.unroll.PickIfElse()).rewrite(pauli_basis_change.code)
# Fixpoint(Walk(DeadCodeElimination())).rewrite(pauli_basis_change.code)
# fold = aggressive.Fold(qasm2.extended)
# fold.fixpoint(pauli_basis_change)
pauli_basis_change.print(hint="const")
stmt = pauli_basis_change.callable_region.blocks[0].stmts.at(4)
print(stmt.results[0])

```