### PR TITLE
error if the statement do not belong to the interpretation

### DIFF
--- a/src/kirin/interp/base.py
+++ b/src/kirin/interp/base.py
@@ -338,6 +338,10 @@ class BaseInterpreter(ABC, Generic[FrameType, ValueType], metaclass=InterpreterM
                     f"method must return tuple or SpecialResult, got {results}"
                 )
             return results
+        elif stmt.dialect not in self.dialects:
+            # NOTE: we should terminate the interpreter because this is a
+            # deveoper error, not a user error.
+            raise ValueError(f"dialect {stmt.dialect} is not supported by {type(self)}")
 
         return self.eval_stmt_fallback(frame, stmt)
 

--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -123,6 +123,17 @@ class DialectGroup(Generic[PassParams]):
             run_pass=self.run_pass_gen,  # pass the run_pass_gen function
         )
 
+    def __contains__(self, dialect) -> bool:
+        """check if the dialect is in the group.
+
+        Args:
+            dialect (Union[Dialect, ModuleType]): the dialect to check.
+
+        Returns:
+            bool: True if the dialect is in the group, False otherwise.
+        """
+        return self.map_module(dialect) in self.data
+
     @property
     def registry(self) -> "Registry":
         """return the registry for the dialect group. This


### PR DESCRIPTION
while I think the major work should be done in a round of validation. But It will be annoying to check that everytime for a developer. So I think we should check this during interpretation for the sake of ergonomics. For performance users, the built-in interpreter is not an option anyways.

cc: @weinbe58 