### PR TITLE
Fix from_stmt does not port current hints.

### DIFF
--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -502,6 +502,10 @@ class Statement(IRNode["Block"]):
             result_types=[result.type for result in other._results],
             args_slice=other._name_args_slice,
         )
+        # inherit the hint:
+        for result, other_result in zip(obj._results, other._results):
+            result.hints = dict(other_result.hints)
+
         return obj
 
     def walk(

--- a/test/ir/test_stmt.py
+++ b/test/ir/test_stmt.py
@@ -39,3 +39,14 @@ def test_block_append():
     block.stmts.append(py.Constant(1))
     block.print()
     assert len(block.stmts) == 2
+
+
+def test_stmt_from_stmt():
+
+    x = py.Constant(1)
+
+    x.result.hints["const"] = py.constant.types.Int
+
+    y = x.from_stmt(x)
+
+    assert y.result.hints["const"] == py.constant.types.Int


### PR DESCRIPTION
Since now lots of analysis passes depending on the hints of result value. 

This PR address issue that when doing clone of a stmt using `from_stmt`, the hints does not carried over.