### PR TITLE
remove verification within scf cons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kirin-toolchain"
-version = "0.13.1"
+version = "0.14.0"
 description = "The Kirin Toolchain for building compilers and interpreters."
 authors = [{ name = "Roger-luo", email = "rluo@quera.com" }]
 dependencies = [

--- a/src/kirin/rewrite/inline.py
+++ b/src/kirin/rewrite/inline.py
@@ -13,7 +13,7 @@ from kirin.dialects.py.constant import Constant
 
 @dataclass
 class Inline(RewriteRule):
-    heuristic: Callable[[ir.IRNode], bool]
+    heuristic: Callable[[ir.Statement], bool]
     """inline heuristic that determines whether a function should be inlined
     """
 


### PR DESCRIPTION
these should be separate verifications on number of blocks in a region because it is possible that at construction a `scf.IfElse` or `scf.For` contains multiple blocks but simplifies to a single one afterwards. We only check this when `verify` is called explicitly. This allows more flexibility for rewrites e.g inlining within `if-else`/`for` body.

This also mark their region uses `SSACFG` convention.