### PR TITLE
Fix bug on Call and GetField

### DIFF
--- a/src/kirin/dialects/func/constprop.py
+++ b/src/kirin/dialects/func/constprop.py
@@ -128,11 +128,18 @@ class DialectConstProp(MethodTable):
         stmt: GetField,
     ) -> StatementResult[const.Result]:
         callee_self = frame.get(stmt.obj)
+
+        # because Call construct a method from lambda with fields are lattice elements
+        # so we need to also check the fields are lattice elem or not
         if isinstance(callee_self, const.Value) and isinstance(
             callee_self.data, ir.Method
         ):
             mt: ir.Method = callee_self.data
-            return (const.Value(mt.fields[stmt.field]),)
+            if isinstance(mt.fields[stmt.field], const.Result):
+                return (mt.fields[stmt.field],)
+            else:
+                return (const.Value(mt.fields[stmt.field]),)
+
         elif isinstance(callee_self, const.PartialLambda):
             return (callee_self.captured[stmt.field],)
         return (const.Unknown(),)

--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -189,7 +189,7 @@ class Lambda(Statement):
 @statement(dialect=dialect)
 class GetField(Statement):
     name = "getfield"
-    traits = frozenset({Pure()})
+    traits = frozenset({MaybePure()})
     obj: SSAValue = info.argument(MethodType)
     field: int = info.attribute()
     # NOTE: mypy somehow doesn't understand default init=False

--- a/test/analysis/dataflow/test_constprop.py
+++ b/test/analysis/dataflow/test_constprop.py
@@ -1,6 +1,6 @@
 from kirin import ir, types
 from kirin.decl import info, statement
-from kirin.prelude import basic_no_opt
+from kirin.prelude import basic, basic_no_opt
 from kirin.analysis import const
 from kirin.dialects import ilist
 
@@ -331,3 +331,25 @@ def test_closure_prop():
     stmt = main2.callable_region.blocks[0].stmts.at(3)
     call_result = frame.entries[stmt.results[0]]
     assert isinstance(call_result, const.Value)
+
+
+def test_call_lambda_prop_with_getfield():
+
+    @basic
+    def my_ps(val: float) -> ir.Method:
+
+        def my_ps_impl():
+            return val * 0.3
+
+        return my_ps_impl
+
+    @basic(fold=True)
+    def my_ps2(val: float):
+
+        my_ps_impl = my_ps(val)
+
+        return my_ps_impl()
+
+    my_ps2.print()
+
+    assert my_ps2(3.0) == 3.0 * 0.3


### PR DESCRIPTION
This PR address #300

1. Change GetField from Pure() to MaybePure() because a field  is specify  by integer which is attribute not argument, and the return value might be Unknown(), and there is no dataflow for this stmt. 
2. Fix constprop interp method for GetField to also check if the method fields are lattice element or not. 