### PR TITLE
switch constant attr to explicit + make IList an attribute

### DIFF
--- a/src/kirin/dialects/func/typeinfer.py
+++ b/src/kirin/dialects/func/typeinfer.py
@@ -24,12 +24,14 @@ class TypeInfer(MethodTable):
         return (types.NoneType,)
 
     @impl(Return)
-    def return_(self, interp: TypeInference, frame: Frame, stmt: Return) -> ReturnValue:
+    def return_(
+        self, interp: TypeInference, frame: Frame[types.TypeAttribute], stmt: Return
+    ) -> ReturnValue:
         if (
             isinstance(hint := stmt.value.hints.get("const"), const.Value)
             and hint.data is not None
         ):
-            return ReturnValue(types.Literal(hint.data))
+            return ReturnValue(types.Literal(hint.data, frame.get(stmt.value)))
         return ReturnValue(frame.get(stmt.value))
 
     @impl(Call)

--- a/src/kirin/ir/__init__.py
+++ b/src/kirin/ir/__init__.py
@@ -45,3 +45,4 @@ from kirin.ir.traits import (
 from kirin.ir.dialect import Dialect as Dialect
 from kirin.ir.attrs.py import PyAttr as PyAttr
 from kirin.ir.attrs.abc import Attribute as Attribute, AttributeMeta as AttributeMeta
+from kirin.ir.attrs.data import Data as Data

--- a/src/kirin/ir/attrs/data.py
+++ b/src/kirin/ir/attrs/data.py
@@ -1,0 +1,28 @@
+from abc import abstractmethod
+from typing import Generic, TypeVar
+from dataclasses import field, dataclass
+
+from .abc import Attribute
+from .types import TypeAttribute
+
+T = TypeVar("T", covariant=True)
+
+
+@dataclass(eq=False)
+class Data(Attribute, Generic[T]):
+    """Base class for data attributes.
+
+    Data attributes are compile-time constants that can be used to
+    represent runtime data inside the IR.
+
+    This class is meant to be subclassed by specific data attributes.
+    It provides a `type` attribute that should be set to the type of
+    the data.
+    """
+
+    type: TypeAttribute = field(init=False, repr=False)
+
+    @abstractmethod
+    def unwrap(self) -> T:
+        """Returns the underlying data value."""
+        ...

--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -1,16 +1,16 @@
-from typing import Generic, TypeVar
+from typing import TypeVar
 from dataclasses import dataclass
 
 from kirin.print import Printer
 
-from .abc import Attribute
+from .data import Data
 from .types import PyClass, TypeAttribute
 
 T = TypeVar("T")
 
 
 @dataclass
-class PyAttr(Generic[T], Attribute):
+class PyAttr(Data[T]):
     """Python attribute for compile-time values.
     This is a generic attribute that holds a Python value.
 
@@ -25,7 +25,6 @@ class PyAttr(Generic[T], Attribute):
 
     name = "PyAttr"
     data: T
-    type: TypeAttribute
 
     def __init__(self, data: T, pytype: TypeAttribute | None = None):
         self.data = data
@@ -43,3 +42,6 @@ class PyAttr(Generic[T], Attribute):
         with printer.rich(style="comment"):
             printer.plain_print(" : ")
             printer.print(self.type)
+
+    def unwrap(self) -> T:
+        return self.data

--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -611,7 +611,7 @@ class Statement(IRNode["Block"]):
             if isinstance(values, SSAValue):
                 printer.print(values)
             else:
-                printer.print_seq(values, delim=", ")
+                printer.print_seq(values, delim=", ", prefix="(", suffix=")")
 
             if idx < len(self._name_args_slice) - 1:
                 printer.plain_print(", ")

--- a/test/dialects/test_ilist.py
+++ b/test/dialects/test_ilist.py
@@ -119,33 +119,33 @@ def test_ilist_fcf():
 
     stmt = foldl.callable_region.blocks[0].stmts.at(2)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 0
+    assert stmt.value.unwrap() == 0
     assert isinstance(foldl.callable_region.blocks[0].stmts.at(4), func.Call)
 
     stmt = foldl.callable_region.blocks[0].stmts.at(5)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 1
+    assert stmt.value.unwrap() == 1
     assert isinstance(foldl.callable_region.blocks[0].stmts.at(7), func.Call)
 
     stmt = foldl.callable_region.blocks[0].stmts.at(8)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 2
+    assert stmt.value.unwrap() == 2
     assert isinstance(foldl.callable_region.blocks[0].stmts.at(10), func.Call)
 
     # ========== foldl
     stmt = foldr.callable_region.blocks[0].stmts.at(2)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 2
+    assert stmt.value.unwrap() == 2
     assert isinstance(foldr.callable_region.blocks[0].stmts.at(4), func.Call)
 
     stmt = foldr.callable_region.blocks[0].stmts.at(5)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 1
+    assert stmt.value.unwrap() == 1
     assert isinstance(foldr.callable_region.blocks[0].stmts.at(7), func.Call)
 
     stmt = foldr.callable_region.blocks[0].stmts.at(8)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == 0
+    assert stmt.value.unwrap() == 0
     assert isinstance(foldr.callable_region.blocks[0].stmts.at(10), func.Call)
 
 
@@ -161,11 +161,3 @@ def test_ilist_range():
         return range(0, 3)
 
     assert const_range() == ilist.IList(range(0, 3))
-
-
-@basic
-def main(xs: ilist.IList[int, Literal[3]]):
-    return xs + [4, 5, 6] + xs
-
-
-main.print()

--- a/test/program/py/test_glob_pi.py
+++ b/test/program/py/test_glob_pi.py
@@ -11,4 +11,4 @@ def test_math_pi():
 
     stmt = main.callable_region.blocks[0].stmts.at(0)
     assert isinstance(stmt, py.Constant)
-    assert stmt.value == math.pi
+    assert stmt.value.unwrap() == math.pi


### PR DESCRIPTION
this PR changes `IList` to an attribute allowing it to be a compile-time value. It also extends the runtime of `IList` so that one can keep track of the element type information at runtime. This solves the problem of capturing global values like below

```python
alist = [1, 2, 3] # could be hard to know element type when list is long
alist = IList([1, 2, 3], elem=types.Int) # allow user explicitly type the global value

@basic
def main()
    return alist
```

This PR is breaking becausae now accessing the `value` field of `Constant` will give either `PyAttr` or some other attribute type (e.g `IList`) instead of original `T` and store as `PyAttr`. This also partially fix #270 . A new attribute base class `Data` and method `unwrap` are provided for convenience to covnert between attribute and runtime Python value.

so this is gonna be a tricky breaking change for downstream because it is hard to detect this behaviour change due to the fact that interpreter won't check its value type. But this will allow us using other attributes as a constant value as part of the python dialect.
