### PR TITLE
Add trait to Attribute base class. 

### DIFF
--- a/src/kirin/ir/attrs/abc.py
+++ b/src/kirin/ir/attrs/abc.py
@@ -41,6 +41,10 @@ class Attribute(ABC, Printable, metaclass=AttributeMeta):
     """Dialect of the attribute. (default: None)"""
     name: ClassVar[str] = field(init=False, repr=False)
     """Name of the attribute in printing and other text format."""
+    traits: ClassVar[frozenset[str]] = field(
+        default=frozenset(), init=False, repr=False
+    )
+    """Set of Attribute traits."""
 
     @abstractmethod
     def __hash__(self) -> int: ...


### PR DESCRIPTION
this PR adds a new class variable `traits` to the attribute base class. Allowing one to annotate attribute with trait. This is a change we use for supporting the text format.