### PR TITLE
Registry for `PyClass` values. 

### DIFF
--- a/src/kirin/dialects/py/builtin.py
+++ b/src/kirin/dialects/py/builtin.py
@@ -76,3 +76,16 @@ class TypeInfer(interp.MethodTable):
     @interp.impl(Abs, types.Float)
     def absf(self, interp, frame, stmt):
         return (types.Float,)
+
+
+dialect.register_py_type(float)
+dialect.register_py_type(int)
+dialect.register_py_type(bool)
+dialect.register_py_type(str)
+dialect.register_py_type(type(None))
+dialect.register_py_type(list)
+dialect.register_py_type(dict)
+dialect.register_py_type(tuple)
+dialect.register_py_type(set)
+dialect.register_py_type(frozenset)
+dialect.register_py_type(slice)

--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -141,9 +141,18 @@ PyClassType = typing.TypeVar("PyClassType")
 class PyClass(TypeAttribute, typing.Generic[PyClassType], metaclass=PyClassMeta):
     name = "PyClass"
     typ: type[PyClassType]
+    display_name: str
+    prefix: str
 
-    def __init__(self, typ: type[PyClassType]) -> None:
+    def __init__(
+        self,
+        typ: type[PyClassType],
+        display_name: str | None = None,
+        prefix: str = "py",
+    ) -> None:
         self.typ = typ
+        self.display_name = display_name if display_name is not None else typ.__name__
+        self.prefix = prefix
 
     def is_subseteq_PyClass(self, other: "PyClass") -> bool:
         return issubclass(self.typ, other.typ)
@@ -170,7 +179,7 @@ class PyClass(TypeAttribute, typing.Generic[PyClassType], metaclass=PyClassMeta)
         return self.typ.__name__
 
     def print_impl(self, printer: Printer) -> None:
-        printer.plain_print("!py.", self.typ.__name__)
+        printer.plain_print(f"!{self.prefix}.", self.display_name)
 
 
 class LiteralMeta(TypeAttributeMeta):

--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -114,7 +114,7 @@ class PyClassMeta(TypeAttributeMeta):
         super(PyClassMeta, self).__init__(*args, **kwargs)
         self._cache = {}
 
-    def __call__(self, typ):
+    def __call__(self, typ, *args, **kwargs):
         if typ is typing.Any:
             return AnyType()
         elif typ is typing.NoReturn or typ is Never:
@@ -128,7 +128,7 @@ class PyClassMeta(TypeAttributeMeta):
         elif isinstance(typ, type) and typ in self._cache:
             return self._cache[typ]
 
-        instance = super(PyClassMeta, self).__call__(typ)
+        instance = super(PyClassMeta, self).__call__(typ, *args, **kwargs)
         self._cache[typ] = instance
         return instance
 

--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -130,30 +130,36 @@ class Dialect:
 
     def register_py_type(
         self,
-        type_or_py_class: type[T] | "PyClass[T]",
+        node: type[T] | "PyClass[T]",
         display_name: str | None = None,
         prefix: str = "py",
     ):
         from kirin.ir.attrs.types import PyClass
 
-        if isinstance(type_or_py_class, type):
-            type_or_py_class = PyClass(
-                type_or_py_class, display_name=display_name, prefix=prefix
-            )
+        if isinstance(node, type):
+            node = PyClass(node, display_name=display_name, prefix=prefix)
+            display_name = node.display_name if display_name is None else display_name
 
-        if isinstance(type_or_py_class, PyClass):
-            if (
-                type_or_py_class.prefix,
-                type_or_py_class.display_name,
-            ) in self.python_types:
+        if isinstance(node, PyClass):
+            if (node.prefix, node.display_name) in self.python_types:
                 raise ValueError(
-                    f"Cannot register {type_or_py_class} to Dialect "
-                    f", key {type_or_py_class.prefix}.{type_or_py_class.display_name} exists"
+                    f"Cannot register {node} to Dialect "
+                    f", key {node.prefix}.{node.display_name} exists"
                 )
 
-            self.python_types[
-                (type_or_py_class.prefix, type_or_py_class.display_name)
-            ] = type_or_py_class
-            return type_or_py_class
+            if node.prefix != prefix:
+                raise ValueError(
+                    f"Cannot register {node} to Dialect "
+                    f", prefix {node.prefix} does not match {prefix}"
+                )
+
+            if node.display_name != display_name:
+                raise ValueError(
+                    f"Cannot register {node} to Dialect "
+                    f", display_name {node.display_name} does not match {display_name}"
+                )
+
+            self.python_types[(node.prefix, node.display_name)] = node
+            return node
         else:
-            raise ValueError(f"Cannot register {type_or_py_class} to Dialect")
+            raise ValueError(f"Cannot register {node} to Dialect")

--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -138,28 +138,17 @@ class Dialect:
 
         if isinstance(node, type):
             node = PyClass(node, display_name=display_name, prefix=prefix)
-            display_name = node.display_name if display_name is None else display_name
 
         if isinstance(node, PyClass):
-            if (node.prefix, node.display_name) in self.python_types:
+            if (node.prefix, node.display_name) in self.python_types and (
+                other_node := self.python_types[(node.prefix, node.display_name)]
+            ) != node:
                 raise ValueError(
-                    f"Cannot register {node} to Dialect "
-                    f", key {node.prefix}.{node.display_name} exists"
-                )
-
-            if node.prefix != prefix:
-                raise ValueError(
-                    f"Cannot register {node} to Dialect "
-                    f", prefix {node.prefix} does not match {prefix}"
-                )
-
-            if node.display_name != display_name:
-                raise ValueError(
-                    f"Cannot register {node} to Dialect "
-                    f", display_name {node.display_name} does not match {display_name}"
+                    f"Cannot register {node} to Dialect, type {other_node.prefix}.{other_node.display_name} exists for {other_node.typ}"
                 )
 
             self.python_types[(node.prefix, node.display_name)] = node
             return node
+
         else:
             raise ValueError(f"Cannot register {node} to Dialect")

--- a/test/ir/test_dialect.py
+++ b/test/ir/test_dialect.py
@@ -1,0 +1,34 @@
+import pytest
+
+from kirin.ir import Dialect
+from kirin.types import PyClass
+
+
+def test_py_type_register():
+
+    class TestClass:
+        pass
+
+    dialect = Dialect("test")
+
+    TestType = dialect.register_py_type(
+        TestClass, display_name="TestType", prefix="test"
+    )
+    assert TestType == PyClass(TestClass, prefix="test", display_name="TestType")
+
+    assert dialect.python_types == {("test", "TestType"): TestType}
+
+    with pytest.raises(ValueError):
+        dialect.register_py_type(TestClass, display_name="TestType", prefix="test")
+
+    with pytest.raises(ValueError):
+        dialect.register_py_type(TestClass, display_name="TestClass", prefix="test")
+
+    with pytest.raises(ValueError):
+        dialect.register_py_type(
+            TestClass, display_name="TestType", prefix="other_prefix"
+        )
+
+
+if __name__ == "__main__":
+    test_py_type_register()

--- a/test/ir/test_dialect.py
+++ b/test/ir/test_dialect.py
@@ -33,5 +33,3 @@ def test_py_type_register():
         )
 
 
-if __name__ == "__main__":
-    test_py_type_register()

--- a/test/ir/test_dialect.py
+++ b/test/ir/test_dialect.py
@@ -9,6 +9,9 @@ def test_py_type_register():
     class TestClass:
         pass
 
+    class OtherTestClass:
+        pass
+
     dialect = Dialect("test")
 
     TestType = dialect.register_py_type(
@@ -19,7 +22,7 @@ def test_py_type_register():
     assert dialect.python_types == {("test", "TestType"): TestType}
 
     with pytest.raises(ValueError):
-        dialect.register_py_type(TestClass, display_name="TestType", prefix="test")
+        dialect.register_py_type(OtherTestClass, display_name="TestType", prefix="test")
 
     with pytest.raises(ValueError):
         dialect.register_py_type(TestClass, display_name="TestClass", prefix="test")

--- a/test/ir/test_dialect.py
+++ b/test/ir/test_dialect.py
@@ -31,5 +31,3 @@ def test_py_type_register():
         dialect.register_py_type(
             TestClass, display_name="TestType", prefix="other_prefix"
         )
-
-


### PR DESCRIPTION
This registry is required for things like Parsing so that there is some way of mapping the string representation of a `PyClass` object to a Type binding. For example when constructing a Function signature from the string: `(type1, type2, ...) -> type3` I need to know how to construct the type binding from the string representation. This PR also allows ones to customize how `PyClass` is printed to avoid naming collisions between different classes, this can be done either by a new prefix or a custom display name for the type. 

A side effect is that going forward it would be good to construct the Type binding using this method directly. For example

```python
from ._dialect import dialect

class Qubit:
   pass

QubitType = dialect.register_py_class(Qubit, ...)

```
