### PR TITLE
`StmtTrait -> Trait[T]` + updating attribute Traits

### DIFF
--- a/src/kirin/dialects/py/indexing.py
+++ b/src/kirin/dialects/py/indexing.py
@@ -30,7 +30,7 @@ GetItemLikeStmt = TypeVar("GetItemLikeStmt", bound=ir.Statement)
 
 
 @dataclass(frozen=True, eq=False)
-class GetItemLike(ir.StmtTrait, Generic[GetItemLikeStmt]):
+class GetItemLike(ir.Trait, Generic[GetItemLikeStmt]):
 
     @abstractmethod
     def get_object(self, stmt: GetItemLikeStmt) -> ir.SSAValue: ...

--- a/src/kirin/dialects/py/indexing.py
+++ b/src/kirin/dialects/py/indexing.py
@@ -30,7 +30,7 @@ GetItemLikeStmt = TypeVar("GetItemLikeStmt", bound=ir.Statement)
 
 
 @dataclass(frozen=True, eq=False)
-class GetItemLike(ir.Trait, Generic[GetItemLikeStmt]):
+class GetItemLike(ir.Trait[ir.Statement], Generic[GetItemLikeStmt]):
 
     @abstractmethod
     def get_object(self, stmt: GetItemLikeStmt) -> ir.SSAValue: ...

--- a/src/kirin/ir/__init__.py
+++ b/src/kirin/ir/__init__.py
@@ -23,9 +23,9 @@ from kirin.ir.nodes import (
 from kirin.ir.method import Method as Method
 from kirin.ir.traits import (
     Pure as Pure,
+    Trait as Trait,
     HasParent as HasParent,
     MaybePure as MaybePure,
-    StmtTrait as StmtTrait,
     RegionTrait as RegionTrait,
     SymbolTable as SymbolTable,
     ConstantLike as ConstantLike,

--- a/src/kirin/ir/attrs/abc.py
+++ b/src/kirin/ir/attrs/abc.py
@@ -50,6 +50,21 @@ class Attribute(ABC, Printable, metaclass=AttributeMeta):
     @abstractmethod
     def __hash__(self) -> int: ...
 
+    @classmethod
+    def has_trait(cls, trait_type: type[Trait["Attribute"]]) -> bool:
+        """Check if the Statement has a specific trait.
+
+        Args:
+            trait_type (type[Trait]): The type of trait to check for.
+
+        Returns:
+            bool: True if the class has the specified trait, False otherwise.
+        """
+        for trait in cls.traits:
+            if isinstance(trait, trait_type):
+                return True
+        return False
+
     TraitType = TypeVar("TraitType", bound=Trait["Attribute"])
 
     def get_trait(self, trait: type[TraitType]) -> Optional[TraitType]:

--- a/src/kirin/ir/attrs/abc.py
+++ b/src/kirin/ir/attrs/abc.py
@@ -1,8 +1,9 @@
 from abc import ABC, ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, TypeVar, ClassVar, Optional
 from dataclasses import field, dataclass
 
 from kirin.print import Printable
+from kirin.ir.traits import Trait
 from kirin.lattice.abc import LatticeMeta, SingletonMeta
 
 if TYPE_CHECKING:
@@ -41,10 +42,27 @@ class Attribute(ABC, Printable, metaclass=AttributeMeta):
     """Dialect of the attribute. (default: None)"""
     name: ClassVar[str] = field(init=False, repr=False)
     """Name of the attribute in printing and other text format."""
-    traits: ClassVar[frozenset[str]] = field(
+    traits: ClassVar[frozenset[Trait["Attribute"]]] = field(
         default=frozenset(), init=False, repr=False
     )
     """Set of Attribute traits."""
 
     @abstractmethod
     def __hash__(self) -> int: ...
+
+    TraitType = TypeVar("TraitType", bound=Trait["Attribute"])
+
+    def get_trait(self, trait: type[TraitType]) -> Optional[TraitType]:
+        """Get the trait of the attribute.
+
+        Args:
+            trait (type[Trait]): the trait to get
+
+        Returns:
+            Optional[Trait]: the trait if found, None otherwise
+        """
+        for t in self.traits:
+            if isinstance(t, trait):
+                return t
+
+        return None

--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 from kirin.print import Printer, Printable
 from kirin.ir.ssa import SSAValue, ResultValue
 from kirin.ir.use import Use
-from kirin.ir.traits import StmtTrait
+from kirin.ir.traits import Trait
 from kirin.ir.attrs.abc import Attribute
 from kirin.ir.nodes.base import IRNode
 from kirin.ir.nodes.view import MutableSequenceView
@@ -132,7 +132,7 @@ class Statement(IRNode["Block"]):
 
     name: ClassVar[str]
     dialect: ClassVar[Dialect | None] = field(default=None, init=False, repr=False)
-    traits: ClassVar[frozenset[StmtTrait]]
+    traits: ClassVar[frozenset[Trait["Statement"]]] = frozenset()
     _arg_groups: ClassVar[frozenset[str]] = frozenset()
 
     _args: tuple[SSAValue, ...] = field(init=False)
@@ -665,7 +665,7 @@ class Statement(IRNode["Block"]):
         return self.attributes.get(key)
 
     @classmethod
-    def has_trait(cls, trait_type: type[StmtTrait]) -> bool:
+    def has_trait(cls, trait_type: type[Trait["Statement"]]) -> bool:
         """Check if the Statement has a specific trait.
 
         Args:
@@ -679,7 +679,7 @@ class Statement(IRNode["Block"]):
                 return True
         return False
 
-    TraitType = TypeVar("TraitType", bound=StmtTrait)
+    TraitType = TypeVar("TraitType", bound=Trait["Statement"])
 
     @classmethod
     def get_trait(cls, trait: type[TraitType]) -> TraitType | None:

--- a/src/kirin/ir/traits/__init__.py
+++ b/src/kirin/ir/traits/__init__.py
@@ -10,7 +10,7 @@ There are also some basic traits that are provided for convenience, such as
 """
 
 from .abc import (
-    StmtTrait as StmtTrait,
+    Trait as Trait,
     RegionTrait as RegionTrait,
     PythonLoweringTrait as PythonLoweringTrait,
 )

--- a/src/kirin/ir/traits/abc.py
+++ b/src/kirin/ir/traits/abc.py
@@ -32,14 +32,14 @@ class RegionTrait(Trait["Region"], Generic[GraphType]):
 
 
 ASTNode = TypeVar("ASTNode", bound=ast.AST)
-StatementType = TypeVar("StatementType", bound="Statement")
+StmtType = TypeVar("StmtType", bound="Statement")
 
 
 @dataclass(frozen=True)
-class PythonLoweringTrait(Trait[StatementType], Generic[StatementType, ASTNode]):
+class PythonLoweringTrait(Trait[StmtType], Generic[StmtType, ASTNode]):
     """A trait that indicates that a statement can be lowered from Python AST."""
 
     @abstractmethod
     def lower(
-        self, stmt: type[StatementType], state: "lowering.LoweringState", node: ASTNode
+        self, stmt: type[StmtType], state: "lowering.LoweringState", node: ASTNode
     ) -> "lowering.Result": ...

--- a/src/kirin/ir/traits/abc.py
+++ b/src/kirin/ir/traits/abc.py
@@ -9,11 +9,14 @@ if TYPE_CHECKING:
     from kirin.graph import Graph
 
 
+IRNodeType = TypeVar("IRNodeType")
+
+
 @dataclass(frozen=True)
-class StmtTrait(ABC):
+class Trait(ABC, Generic[IRNodeType]):
     """Base class for all statement traits."""
 
-    def verify(self, stmt: "Statement"):
+    def verify(self, node: IRNodeType):
         pass
 
 
@@ -21,7 +24,7 @@ GraphType = TypeVar("GraphType", bound="Graph[Block]")
 
 
 @dataclass(frozen=True)
-class RegionTrait(StmtTrait, Generic[GraphType]):
+class RegionTrait(Trait["Region"], Generic[GraphType]):
     """A trait that indicates the properties of the statement's region."""
 
     @abstractmethod
@@ -33,7 +36,7 @@ StatementType = TypeVar("StatementType", bound="Statement")
 
 
 @dataclass(frozen=True)
-class PythonLoweringTrait(StmtTrait, Generic[StatementType, ASTNode]):
+class PythonLoweringTrait(Trait[StatementType], Generic[StatementType, ASTNode]):
     """A trait that indicates that a statement can be lowered from Python AST."""
 
     @abstractmethod

--- a/src/kirin/ir/traits/basic.py
+++ b/src/kirin/ir/traits/basic.py
@@ -1,14 +1,14 @@
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
-from .abc import StmtTrait
+from .abc import Trait
 
 if TYPE_CHECKING:
     from kirin.ir import Statement
 
 
 @dataclass(frozen=True)
-class Pure(StmtTrait):
+class Pure(Trait):
     """A trait that indicates that a statement is pure, i.e., it has no side
     effects.
     """
@@ -17,7 +17,7 @@ class Pure(StmtTrait):
 
 
 @dataclass(frozen=True)
-class MaybePure(StmtTrait):
+class MaybePure(Trait):
     """A trait that indicates the statement may be pure,
     i.e., a call statement can be pure if the callee is pure.
     """
@@ -40,7 +40,7 @@ class MaybePure(StmtTrait):
 
 
 @dataclass(frozen=True)
-class ConstantLike(StmtTrait):
+class ConstantLike(Trait):
     """A trait that indicates that a statement is constant-like, i.e., it
     represents a constant value.
     """
@@ -49,7 +49,7 @@ class ConstantLike(StmtTrait):
 
 
 @dataclass(frozen=True)
-class IsTerminator(StmtTrait):
+class IsTerminator(Trait):
     """A trait that indicates that a statement is a terminator, i.e., it
     terminates a block.
     """
@@ -58,19 +58,19 @@ class IsTerminator(StmtTrait):
 
 
 @dataclass(frozen=True)
-class NoTerminator(StmtTrait):
+class NoTerminator(Trait):
     """A trait that indicates that the region of a statement has no terminator."""
 
     pass
 
 
 @dataclass(frozen=True)
-class IsolatedFromAbove(StmtTrait):
+class IsolatedFromAbove(Trait):
     pass
 
 
 @dataclass(frozen=True)
-class HasParent(StmtTrait):
+class HasParent(Trait):
     """A trait that indicates that a statement has a parent
     statement.
     """

--- a/src/kirin/ir/traits/basic.py
+++ b/src/kirin/ir/traits/basic.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class Pure(Trait):
+class Pure(Trait["Statement"]):
     """A trait that indicates that a statement is pure, i.e., it has no side
     effects.
     """
@@ -17,7 +17,7 @@ class Pure(Trait):
 
 
 @dataclass(frozen=True)
-class MaybePure(Trait):
+class MaybePure(Trait["Statement"]):
     """A trait that indicates the statement may be pure,
     i.e., a call statement can be pure if the callee is pure.
     """
@@ -40,7 +40,7 @@ class MaybePure(Trait):
 
 
 @dataclass(frozen=True)
-class ConstantLike(Trait):
+class ConstantLike(Trait["Statement"]):
     """A trait that indicates that a statement is constant-like, i.e., it
     represents a constant value.
     """
@@ -49,7 +49,7 @@ class ConstantLike(Trait):
 
 
 @dataclass(frozen=True)
-class IsTerminator(Trait):
+class IsTerminator(Trait["Statement"]):
     """A trait that indicates that a statement is a terminator, i.e., it
     terminates a block.
     """
@@ -58,19 +58,19 @@ class IsTerminator(Trait):
 
 
 @dataclass(frozen=True)
-class NoTerminator(Trait):
+class NoTerminator(Trait["Statement"]):
     """A trait that indicates that the region of a statement has no terminator."""
 
     pass
 
 
 @dataclass(frozen=True)
-class IsolatedFromAbove(Trait):
+class IsolatedFromAbove(Trait["Statement"]):
     pass
 
 
 @dataclass(frozen=True)
-class HasParent(Trait):
+class HasParent(Trait["Statement"]):
     """A trait that indicates that a statement has a parent
     statement.
     """

--- a/src/kirin/ir/traits/callable.py
+++ b/src/kirin/ir/traits/callable.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
 from dataclasses import dataclass
 
-from kirin.ir.traits.abc import StmtTrait
+from kirin.ir.traits.abc import Trait
 
 if TYPE_CHECKING:
     from kirin.ir import Region, Statement
@@ -12,7 +12,7 @@ StmtType = TypeVar("StmtType", bound="Statement")
 
 
 @dataclass(frozen=True)
-class CallableStmtInterface(StmtTrait, Generic[StmtType]):
+class CallableStmtInterface(Trait, Generic[StmtType]):
     """A trait that indicates that a statement is a callable statement.
 
     A callable statement is a statement that can be called as a function.
@@ -26,7 +26,7 @@ class CallableStmtInterface(StmtTrait, Generic[StmtType]):
 
 
 @dataclass(frozen=True)
-class HasSignature(StmtTrait, ABC):
+class HasSignature(Trait, ABC):
     """A trait that indicates that a statement has a function signature
     attribute.
     """

--- a/src/kirin/ir/traits/callable.py
+++ b/src/kirin/ir/traits/callable.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from dataclasses import dataclass
 
 from kirin.ir.traits.abc import Trait
@@ -12,7 +12,7 @@ StmtType = TypeVar("StmtType", bound="Statement")
 
 
 @dataclass(frozen=True)
-class CallableStmtInterface(Trait, Generic[StmtType]):
+class CallableStmtInterface(Trait[StmtType]):
     """A trait that indicates that a statement is a callable statement.
 
     A callable statement is a statement that can be called as a function.
@@ -26,13 +26,13 @@ class CallableStmtInterface(Trait, Generic[StmtType]):
 
 
 @dataclass(frozen=True)
-class HasSignature(Trait, ABC):
+class HasSignature(Trait[StmtType], ABC):
     """A trait that indicates that a statement has a function signature
     attribute.
     """
 
     @classmethod
-    def get_signature(cls, stmt: "Statement"):
+    def get_signature(cls, stmt: StmtType):
         signature: Signature | None = stmt.attributes.get("signature")  # type: ignore
         if signature is None:
             raise ValueError(f"Statement {stmt.name} does not have a function type")
@@ -40,10 +40,10 @@ class HasSignature(Trait, ABC):
         return signature
 
     @classmethod
-    def set_signature(cls, stmt: "Statement", signature: "Signature"):
+    def set_signature(cls, stmt: StmtType, signature: "Signature"):
         stmt.attributes["signature"] = signature
 
-    def verify(self, stmt: "Statement"):
+    def verify(self, stmt: StmtType):
         from kirin.dialects.func.attrs import Signature
 
         signature = self.get_signature(stmt)

--- a/src/kirin/ir/traits/symbol.py
+++ b/src/kirin/ir/traits/symbol.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 
 from kirin.exceptions import VerificationError
 from kirin.ir.attrs.py import PyAttr
-from kirin.ir.traits.abc import StmtTrait
+from kirin.ir.traits.abc import Trait
 
 if TYPE_CHECKING:
     from kirin.ir import Statement
 
 
 @dataclass(frozen=True)
-class SymbolOpInterface(StmtTrait):
+class SymbolOpInterface(Trait):
     """A trait that indicates that a statement is a symbol operation.
 
     A symbol operation is a statement that has a symbol name attribute.
@@ -32,7 +32,7 @@ class SymbolOpInterface(StmtTrait):
 
 
 @dataclass(frozen=True)
-class SymbolTable(StmtTrait):
+class SymbolTable(Trait):
     """
     Statement with SymbolTable trait can only have one region with one block.
     """

--- a/src/kirin/ir/traits/symbol.py
+++ b/src/kirin/ir/traits/symbol.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 from dataclasses import dataclass
 
 from kirin.exceptions import VerificationError
@@ -8,22 +8,24 @@ from kirin.ir.traits.abc import Trait
 if TYPE_CHECKING:
     from kirin.ir import Statement
 
+StmtType = TypeVar("StmtType", bound="Statement")
+
 
 @dataclass(frozen=True)
-class SymbolOpInterface(Trait):
+class SymbolOpInterface(Trait[StmtType]):
     """A trait that indicates that a statement is a symbol operation.
 
     A symbol operation is a statement that has a symbol name attribute.
     """
 
-    def get_sym_name(self, stmt: "Statement") -> "PyAttr[str]":
+    def get_sym_name(self, stmt: StmtType) -> "PyAttr[str]":
         sym_name: PyAttr[str] | None = stmt.get_attr_or_prop("sym_name")  # type: ignore
         # NOTE: unlike MLIR or xDSL we do not allow empty symbol names
         if sym_name is None:
             raise ValueError(f"Statement {stmt.name} does not have a symbol name")
         return sym_name
 
-    def verify(self, stmt: "Statement"):
+    def verify(self, stmt: StmtType):
         from kirin.types import String
 
         sym_name = self.get_sym_name(stmt)
@@ -32,16 +34,16 @@ class SymbolOpInterface(Trait):
 
 
 @dataclass(frozen=True)
-class SymbolTable(Trait):
+class SymbolTable(Trait[StmtType]):
     """
     Statement with SymbolTable trait can only have one region with one block.
     """
 
     @staticmethod
-    def walk(stmt: "Statement"):
+    def walk(stmt: StmtType):
         return stmt.regions[0].blocks[0].stmts
 
-    def verify(self, stmt: "Statement"):
+    def verify(self, stmt: StmtType):
         if len(stmt.regions) != 1:
             raise VerificationError(
                 stmt,


### PR DESCRIPTION
Per discussion with @Roger-luo this PR renames the base class of Traits and also makes it generic for better hinting. I also realized my last PR on Attribute traits was missing an implementation of `get_trait` so this PR also adds that as well. 