### PR TITLE
correct region trait parent node type

### DIFF
--- a/src/kirin/ir/traits/abc.py
+++ b/src/kirin/ir/traits/abc.py
@@ -24,7 +24,7 @@ GraphType = TypeVar("GraphType", bound="Graph[Block]")
 
 
 @dataclass(frozen=True)
-class RegionTrait(Trait["Region"], Generic[GraphType]):
+class RegionTrait(Trait["Statement"], Generic[GraphType]):
     """A trait that indicates the properties of the statement's region."""
 
     @abstractmethod


### PR DESCRIPTION
`Region` is part of a statement so the trait belongs to a statement not a region.