### PR TITLE
fix: rewrite scf trim should update scf.for initializers and entries

### DIFF
--- a/src/kirin/dialects/scf/trim.py
+++ b/src/kirin/dialects/scf/trim.py
@@ -8,10 +8,7 @@ from .stmts import For, Yield, IfElse
 class UnusedYield(RewriteRule):
     """Trim unused results from `For` and `IfElse` statements."""
 
-    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
-        if not isinstance(node, (For, IfElse)):
-            return RewriteResult()
-
+    def scan_unused(self, node: ir.Statement):
         any_unused = False
         uses: list[int] = []
         results: list[ir.ResultValue] = []
@@ -21,7 +18,13 @@ class UnusedYield(RewriteRule):
                 results.append(result)
             else:
                 any_unused = True
+        return any_unused, set(uses), results
 
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, (For, IfElse)):
+            return RewriteResult()
+
+        any_unused, uses, results = self.scan_unused(node)
         if not any_unused:
             return RewriteResult()
 
@@ -33,4 +36,10 @@ class UnusedYield(RewriteRule):
 
                 block.last_stmt.args = [block.last_stmt.args[idx] for idx in uses]
 
+        if isinstance(node, For):
+            for idx, block_arg in enumerate(node.body.blocks[0].args[1:]):
+                if idx not in uses:
+                    block_arg.replace_by(node.initializers[idx])
+                    block_arg.delete()
+            node.initializers = tuple(node.initializers[idx] for idx in uses)
         return RewriteResult(has_done_something=True)

--- a/src/kirin/ir/ssa.py
+++ b/src/kirin/ir/ssa.py
@@ -152,6 +152,9 @@ class BlockArgument(SSAValue):
     def owner(self) -> Block:
         return self.block
 
+    def delete(self, safe: bool = True) -> None:
+        self.block.args.delete(self, safe=safe)
+
     def __hash__(self) -> int:
         return id(self)
 

--- a/test/dialects/scf/test_for.py
+++ b/test/dialects/scf/test_for.py
@@ -64,3 +64,16 @@ def test_issue_213():
 
     assert main.py_func is not None
     assert main() == main.py_func()
+
+
+def test_simple_assign():
+    @python_basic.union(
+        [func, scf, py.unpack, lowering.func, ilist, lowering.range.ilist]
+    )
+    def main(n: int):
+        x = 0
+        for i in range(n):
+            x = i
+        return x
+
+    assert main(5) == 4

--- a/test/dialects/scf/test_for.py
+++ b/test/dialects/scf/test_for.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kirin import ir, types
+from kirin import ir, types, rewrite
 from kirin.prelude import python_basic
 from kirin.dialects import py, scf, func, ilist, lowering
 from kirin.exceptions import VerificationError
@@ -77,3 +77,22 @@ def test_simple_assign():
         return x
 
     assert main(5) == 4
+
+
+def test_unused_loop_vars():
+    @python_basic.union(
+        [func, scf, py.unpack, lowering.func, ilist, lowering.range.ilist]
+    )
+    def main(n: int):
+        x = 0
+        offset = 1
+        for i in range(n):
+            x = i + offset
+        return x
+
+    rewrite.Walk(scf.trim.UnusedYield()).rewrite(main.code)
+    loop = main.callable_region.blocks[0].stmts.at(-2)
+    assert isinstance(loop, scf.For)
+    assert len(loop.initializers) == 1
+    assert len(loop.body.blocks[0].args) == 2
+    # assert main(5) == 4


### PR DESCRIPTION
partially fix #322 as this only corrects the generated code not triggering validation error but the code does not fold correctly