### PR TITLE
feat: add a builtin option for Pass to not raise

### DIFF
--- a/src/kirin/analysis/typeinfer/analysis.py
+++ b/src/kirin/analysis/typeinfer/analysis.py
@@ -26,11 +26,15 @@ class TypeInference(Forward[types.TypeAttribute]):
     lattice = types.TypeAttribute
 
     def run_analysis(
-        self, method: ir.Method, args: tuple[types.TypeAttribute, ...] | None = None
+        self,
+        method: ir.Method,
+        args: tuple[types.TypeAttribute, ...] | None = None,
+        *,
+        no_raise: bool = True,
     ) -> tuple[ForwardFrame[types.TypeAttribute], types.TypeAttribute]:
         if args is None:
             args = method.arg_types
-        return super().run_analysis(method, args)
+        return super().run_analysis(method, args, no_raise=no_raise)
 
     # NOTE: unlike concrete interpreter, instead of using type information
     # within the IR. Type inference will use the interpreted

--- a/src/kirin/passes/abc.py
+++ b/src/kirin/passes/abc.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import ClassVar
-from dataclasses import dataclass
+from dataclasses import field, dataclass
 
 from kirin.ir import Method, DialectGroup
 from kirin.rewrite.abc import RewriteResult
@@ -24,6 +24,7 @@ class Pass(ABC):
 
     name: ClassVar[str]
     dialects: DialectGroup
+    no_raise: bool = field(default=False, kw_only=True)
 
     def __call__(self, mt: Method) -> RewriteResult:
         result = self.unsafe_run(mt)

--- a/src/kirin/passes/aggressive/fold.py
+++ b/src/kirin/passes/aggressive/fold.py
@@ -28,7 +28,7 @@ class Fold(Pass):
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
         result = RewriteResult()
-        frame, _ = self.constprop.run_analysis(mt)
+        frame, _ = self.constprop.run_analysis(mt, no_raise=self.no_raise)
         result = Walk(WrapConst(frame)).rewrite(mt.code).join(result)
         rule = Chain(
             ConstantFold(),

--- a/src/kirin/passes/fold.py
+++ b/src/kirin/passes/fold.py
@@ -22,7 +22,7 @@ class Fold(Pass):
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
         constprop = const.Propagate(self.dialects)
-        frame, _ = constprop.run_analysis(mt)
+        frame, _ = constprop.run_analysis(mt, no_raise=self.no_raise)
         result = Walk(WrapConst(frame)).rewrite(mt.code)
         result = (
             Fixpoint(

--- a/src/kirin/passes/typeinfer.py
+++ b/src/kirin/passes/typeinfer.py
@@ -17,7 +17,9 @@ class TypeInfer(Pass):
         self.infer = TypeInference(self.dialects)
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
-        frame, return_type = self.infer.run_analysis(mt, mt.arg_types)
+        frame, return_type = self.infer.run_analysis(
+            mt, mt.arg_types, no_raise=self.no_raise
+        )
         if trait := mt.code.get_trait(HasSignature):
             trait.set_signature(mt.code, Signature(mt.arg_types, return_type))
 


### PR DESCRIPTION
closes #347 

I didn't add it in `unsafe_run` because the `@dataclass` object of pass was designed to store those Pass configurations.