### PR TITLE
feat: add get_casted to force linter accepting a type

### DIFF
--- a/src/kirin/interp/frame.py
+++ b/src/kirin/interp/frame.py
@@ -125,6 +125,19 @@ class Frame(FrameABC[ValueType]):
 
     ExpectedType = TypeVar("ExpectedType")
 
+    def get_casted(self, key: SSAValue, type_: type[ExpectedType]) -> ExpectedType:
+        """Same as [`get`][kirin.interp.frame.Frame.get] except it
+        forces the linter to think the value is of the expected type.
+
+        Args:
+            key(SSAValue): The key to get the value for.
+            type_(type): The expected type.
+
+        Returns:
+            ExpectedType: The value.
+        """
+        return self.get(key)  # type: ignore
+
     def get_typed(self, key: SSAValue, type_: type[ExpectedType]) -> ExpectedType:
         """Similar to [`get`][kirin.interp.frame.Frame.get] but also checks the type.
 


### PR DESCRIPTION
while in most cases `.get` is sufficient, having `.get_casted` allows linter to provide more specific auto-complete if the author is pretty sure about the resulting type.