### PR TITLE
polish lowering

### DIFF
--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -110,7 +110,7 @@ class Dialect:
             elif issubclass(node, MethodTable):
                 if key in self.interps:
                     raise ValueError(
-                        f"Cannot register {node} to Dialect, key {key} exists"
+                        f"Cannot register {node} to Dialect, key {key} exists in {self}"
                     )
                 self.interps[key] = node()
             elif issubclass(node, FromPythonAST):

--- a/src/kirin/lowering/abc.py
+++ b/src/kirin/lowering/abc.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, TypeAlias
 from dataclasses import dataclass
 
-from kirin.ir import SSAValue, Statement, DialectGroup
+from kirin.ir import Region, SSAValue, Statement, DialectGroup
 
 from .exception import BuildError
 
@@ -49,7 +49,7 @@ class LoweringABC(ABC, Generic[ASTNodeType]):
         lineno_offset: int = 0,
         col_offset: int = 0,
         compactify: bool = True,
-    ) -> Statement: ...
+    ) -> Region: ...
 
     @abstractmethod
     def visit(self, state: State[ASTNodeType], node: ASTNodeType) -> Result:

--- a/src/kirin/lowering/frame.py
+++ b/src/kirin/lowering/frame.py
@@ -65,7 +65,7 @@ class Frame(Generic[Stmt]):
             raise BuildError(f"unexpected builtin statement {stmt.name}")
         elif stmt.dialect not in self.state.parent.dialects:
             raise BuildError(
-                f"Unsupported dialect `{stmt.dialect.name}` in statement {stmt.name}"
+                f"Unsupported dialect `{stmt.dialect.name}` from statement {stmt.name}"
             )
         self.curr_block.stmts.append(stmt)
         if stmt.source is None:

--- a/src/kirin/lowering/python/glob.py
+++ b/src/kirin/lowering/python/glob.py
@@ -23,9 +23,14 @@ class GlobalExprEval(ast.NodeVisitor):
     frame: Frame
 
     def generic_visit(self, node: ast.AST) -> Any:
+        if isinstance(node, ast.AST):
+            raise GlobalEvalError(
+                node,
+                f"Cannot lower global {node.__class__.__name__} node: {ast.dump(node)}",
+            )
         raise GlobalEvalError(
             node,
-            f"Cannot lower global {node.__class__.__name__} node: {ast.dump(node)}",
+            f"Unexpected global `{node.__class__.__name__}` node: {repr(node)} is not an AST node",
         )
 
     def visit_Name(self, node: ast.Name) -> Any:

--- a/src/kirin/lowering/state.py
+++ b/src/kirin/lowering/state.py
@@ -50,7 +50,7 @@ class State(Generic[ASTNodeType]):
     "current frame being lowered"
 
     def __repr__(self) -> str:
-        return f"lowering.State({self.current_frame})"
+        return f"lowering.State(current_frame={self._current_frame})"
 
     @property
     def code(self):
@@ -178,6 +178,11 @@ class State(Generic[ASTNodeType]):
         entr_block = entr_block or Block()
         region.blocks.append(entr_block)
 
+        if self._current_frame is not None:
+            globals = globals or self.current_frame.globals
+        else:
+            globals = globals or {}
+
         frame = Frame(
             state=self,
             stream=stmts,
@@ -185,7 +190,7 @@ class State(Generic[ASTNodeType]):
             entr_block=entr_block,
             curr_block=entr_block,
             next_block=next_block or Block(),
-            globals=globals or self.current_frame.globals,
+            globals=globals,
             capture_callback=capture_callback,
         )
         self.push_frame(frame)


### PR DESCRIPTION
change the return of `lowering.run` from `Statement` to `Region` so we can keep the original result as much as possible. We return `ir.Statement` only for `python_function` because a function is mapped to a `Statement`.