### PR TITLE
fix empty union

### DIFF
--- a/src/kirin/lattice/abc.py
+++ b/src/kirin/lattice/abc.py
@@ -90,6 +90,12 @@ class BoundedLattice(Lattice[BoundedLatticeType]):
 class UnionMeta(LatticeMeta):
     """Meta class for union types. It simplifies the union if possible."""
 
+    def __init__(self, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        if not issubclass(base := bases[0], BoundedLattice):
+            raise TypeError(f"Union must inherit from Lattice, got {bases[0]}")
+        self._bottom = base.bottom()
+
     def __call__(
         self,
         typ: Iterable[LatticeType] | LatticeType,
@@ -125,4 +131,6 @@ class UnionMeta(LatticeMeta):
         if len(params) == 1:
             return params[0]
 
+        if len(params) == 0:
+            return self._bottom
         return super(UnionMeta, self).__call__(*params)

--- a/test/dialects/test_pytypes.py
+++ b/test/dialects/test_pytypes.py
@@ -29,6 +29,7 @@ class Derived(Base):
 
 
 def test_union():
+    assert Union({}) is BottomType()
     assert PyClass(int) | PyClass(float) == Union(PyClass(int), PyClass(float))
     assert Union(PyClass(int), PyClass(int)) == PyClass(int)
     assert Union(PyClass(int), PyClass(float)) == Union(PyClass(int), PyClass(float))


### PR DESCRIPTION
while one would just use `BottomType` for empty `Union` it is possible to write `Union({})` this fixes the error