### PR TITLE
refactor interp to clean up APIs + improve stacktrace

### DIFF
--- a/src/kirin/analysis/const/prop.py
+++ b/src/kirin/analysis/const/prop.py
@@ -52,8 +52,10 @@ class Propagate(ForwardExtra[Frame, Result]):
         self._interp.initialize()
         return self
 
-    def new_frame(self, code: ir.Statement) -> Frame:
-        return Frame.from_func_like(code)
+    def initialize_frame(
+        self, code: ir.Statement, *, has_parent_access: bool = False
+    ) -> Frame:
+        return Frame(code, has_parent_access=has_parent_access)
 
     def try_eval_const_pure(
         self,
@@ -61,7 +63,7 @@ class Propagate(ForwardExtra[Frame, Result]):
         stmt: ir.Statement,
         values: tuple[Value, ...],
     ) -> interp.StatementResult[Result]:
-        _frame = self._interp.new_frame(frame.code)
+        _frame = self._interp.initialize_frame(frame.code)
         _frame.set_values(stmt.args, tuple(x.data for x in values))
         method = self._interp.lookup_registry(frame, stmt)
         if method is not None:

--- a/src/kirin/analysis/forward.py
+++ b/src/kirin/analysis/forward.py
@@ -69,7 +69,7 @@ class ForwardExtra(
             # so we don't need to copy the frames.
             if not no_raise:
                 raise e
-            return self.new_frame(method.code), self.lattice.bottom()
+            return self.state.current_frame, self.lattice.bottom()
         finally:
             self._eval_lock = False
             sys.setrecursionlimit(current_recursion_limit)
@@ -103,5 +103,7 @@ class Forward(ForwardExtra[ForwardFrame[LatticeElemType], LatticeElemType], ABC)
     [`ForwardExtra`][kirin.analysis.forward.ForwardExtra] instead.
     """
 
-    def new_frame(self, code: ir.Statement) -> ForwardFrame[LatticeElemType]:
-        return ForwardFrame.from_func_like(code)
+    def initialize_frame(
+        self, code: ir.Statement, *, has_parent_access: bool = False
+    ) -> ForwardFrame[LatticeElemType]:
+        return ForwardFrame(code, has_parent_access=has_parent_access)

--- a/src/kirin/dialects/cf/constprop.py
+++ b/src/kirin/dialects/cf/constprop.py
@@ -9,7 +9,7 @@ class DialectConstProp(MethodTable):
 
     @impl(Branch)
     def branch(self, interp: const.Propagate, frame: const.Frame, stmt: Branch):
-        interp.state.current_frame().worklist.append(
+        interp.state.current_frame.worklist.append(
             Successor(stmt.successor, *frame.get_values(stmt.arguments))
         )
         return ()
@@ -21,7 +21,7 @@ class DialectConstProp(MethodTable):
         frame: const.Frame,
         stmt: ConditionalBranch,
     ):
-        frame = interp.state.current_frame()
+        frame = interp.state.current_frame
         cond = frame.get(stmt.cond)
         if isinstance(cond, const.Value):
             else_successor = Successor(

--- a/src/kirin/dialects/scf/absint.py
+++ b/src/kirin/dialects/scf/absint.py
@@ -56,9 +56,7 @@ class Methods(interp.MethodTable):
             frame.worklist.append(interp.Successor(body_block, frame.get(stmt.cond)))
             return
 
-        with interp_.state.new_frame(interp_.new_frame(stmt)) as body_frame:
-            body_frame.entries.update(frame.entries)
-            body_frame.set(body_block.args[0], frame.get(stmt.cond))
-            ret = interp_.run_ssacfg_region(body_frame, body)
+        with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
+            ret = interp_.run_ssacfg_region(body_frame, body, (frame.get(stmt.cond),))
             frame.entries.update(body_frame.entries)
-            return ret
+        return ret

--- a/src/kirin/dialects/scf/interp.py
+++ b/src/kirin/dialects/scf/interp.py
@@ -18,16 +18,16 @@ class Concrete(interp.MethodTable):
             body = stmt.then_body
         else:
             body = stmt.else_body
-        return interp_.run_ssacfg_region(frame, body)
+        return interp_.run_ssacfg_region(frame, body, (cond,))
 
     @interp.impl(For)
     def for_loop(self, interpreter: interp.Interpreter, frame: interp.Frame, stmt: For):
         iterable = frame.get(stmt.iterable)
         loop_vars = frame.get_values(stmt.initializers)
-        block_args = stmt.body.blocks[0].args
         for value in iterable:
-            frame.set_values(block_args, (value,) + loop_vars)
-            loop_vars = interpreter.run_ssacfg_region(frame, stmt.body)
+            loop_vars = interpreter.run_ssacfg_region(
+                frame, stmt.body, (value,) + loop_vars
+            )
             if isinstance(loop_vars, interp.ReturnValue):
                 return loop_vars
             elif loop_vars is None:

--- a/src/kirin/dialects/scf/typeinfer.py
+++ b/src/kirin/dialects/scf/typeinfer.py
@@ -45,9 +45,10 @@ class TypeInfer(absint.Methods):
             frame.worklist.append(interp.Successor(body_block, item, *loop_vars))
             return  # if terminate is Return, there is no result
 
-        with interp_.state.new_frame(interp_.new_frame(stmt)) as body_frame:
-            body_frame.entries.update(frame.entries)
-            loop_vars_ = interp_.run_ssacfg_region(body_frame, stmt.body)
+        with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
+            loop_vars_ = interp_.run_ssacfg_region(
+                body_frame, stmt.body, (iterable,) + loop_vars
+            )
 
         frame.entries.update(body_frame.entries)
         if isinstance(loop_vars_, interp.ReturnValue):

--- a/src/kirin/emit/abc.pyi
+++ b/src/kirin/emit/abc.pyi
@@ -15,10 +15,14 @@ FrameType = TypeVar("FrameType", bound=EmitFrame)
 
 class EmitABC(interp.BaseInterpreter[FrameType, ValueType]):
     def run_callable_region(
-        self, frame: FrameType, code: ir.Statement, region: ir.Region
+        self,
+        frame: FrameType,
+        code: ir.Statement,
+        region: ir.Region,
+        args: tuple[ValueType, ...],
     ) -> ValueType: ...
     def run_ssacfg_region(
-        self, frame: FrameType, region: ir.Region
+        self, frame: FrameType, region: ir.Region, args: tuple[ValueType, ...]
     ) -> tuple[ValueType, ...]: ...
     def emit_attribute(self, attr: ir.Attribute) -> ValueType: ...
     def emit_type_Any(self, attr: types.AnyType) -> ValueType: ...

--- a/src/kirin/emit/str.py
+++ b/src/kirin/emit/str.py
@@ -29,13 +29,15 @@ class EmitStr(EmitABC[EmitStrFrame, str], ABC, Generic[IO_t]):
         self.block_id = idtable.IdTable[ir.Block](prefix=self.prefix + "block_")
         return self
 
-    def new_frame(self, code: ir.Statement) -> EmitStrFrame:
-        return EmitStrFrame.from_func_like(code)
+    def initialize_frame(
+        self, code: ir.Statement, *, has_parent_access: bool = False
+    ) -> EmitStrFrame:
+        return EmitStrFrame(code, has_parent_access=has_parent_access)
 
     def run_method(
         self, method: ir.Method, args: tuple[str, ...]
     ) -> tuple[EmitStrFrame, str]:
-        if len(self.state.frames) >= self.max_depth:
+        if self.state.depth >= self.max_depth:
             raise interp.InterpreterError("maximum recursion depth exceeded")
         return self.run_callable(method.code, (method.sym_name,) + args)
 

--- a/src/kirin/interp/value.py
+++ b/src/kirin/interp/value.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Generic, TypeVar, TypeAlias, final
+from typing import Generic, TypeVar, TypeAlias, final
 from dataclasses import dataclass
 
 from kirin.ir import Block
@@ -51,7 +51,7 @@ class Successor(Generic[ValueType]):
     """Successor block from a statement evaluation."""
 
     block: Block
-    block_args: Tuple[ValueType, ...]
+    block_args: tuple[ValueType, ...]
 
     def __init__(self, block: Block, *block_args: ValueType):
         super().__init__()

--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -146,6 +146,9 @@ class Statement(IRNode["Block"]):
     _next_stmt: Statement | None = field(default=None, init=False, repr=False)
     _prev_stmt: Statement | None = field(default=None, init=False, repr=False)
 
+    source: SourceInfo | None = field(default=None, init=False, repr=False)
+    """The source information of the Statement for debugging/stacktracing."""
+
     # NOTE: This is only for syntax sugar to provide
     # access to args via the properties
     _name_args_slice: dict[str, int | slice] = field(


### PR DESCRIPTION
this PR cleans up the double `new_frame` API in the interpreter framework (closes #363). We also refactor the `run_ssacfg_region` and deprecate `run_block` interface to make linter happier (it was not consistent in `AbstractInterpreter` vs `BaseInterpreter`). 

We still need some further thinking on what is a value of `region` and `block` (determine by their terminating statement/block?) so that codegen framework can share more codebase with interpreter.