### PR TITLE
feat: add a canonicalize + post inference hook to ir.Dialect

### DIFF
--- a/src/kirin/dialects/ilist/rewrite/const.py
+++ b/src/kirin/dialects/ilist/rewrite/const.py
@@ -9,7 +9,7 @@ from ..runtime import IList
 from .._dialect import dialect
 
 
-@dialect.inference
+@dialect.post_inference
 class ConstList2IList(RewriteRule):
     """Rewrite type annotation for SSAValue with constant `IList`
     in `Hinted` type. This should be run after constant folding and

--- a/src/kirin/dialects/ilist/rewrite/const.py
+++ b/src/kirin/dialects/ilist/rewrite/const.py
@@ -6,8 +6,10 @@ from kirin.dialects.py.constant import Constant
 
 from ..stmts import IListType
 from ..runtime import IList
+from .._dialect import dialect
 
 
+@dialect.inference
 class ConstList2IList(RewriteRule):
     """Rewrite type annotation for SSAValue with constant `IList`
     in `Hinted` type. This should be run after constant folding and

--- a/src/kirin/dialects/ilist/rewrite/hint_len.py
+++ b/src/kirin/dialects/ilist/rewrite/hint_len.py
@@ -7,7 +7,7 @@ from kirin.dialects.ilist.stmts import IListType
 from .._dialect import dialect
 
 
-@dialect.inference
+@dialect.post_inference
 class HintLen(RewriteRule):
 
     def _get_collection_len(self, collection: ir.SSAValue):

--- a/src/kirin/dialects/ilist/rewrite/hint_len.py
+++ b/src/kirin/dialects/ilist/rewrite/hint_len.py
@@ -4,7 +4,10 @@ from kirin.dialects import py
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 from kirin.dialects.ilist.stmts import IListType
 
+from .._dialect import dialect
 
+
+@dialect.inference
 class HintLen(RewriteRule):
 
     def _get_collection_len(self, collection: ir.SSAValue):

--- a/src/kirin/dialects/ilist/rewrite/list.py
+++ b/src/kirin/dialects/ilist/rewrite/list.py
@@ -5,7 +5,10 @@ from kirin.rewrite.result import RewriteResult
 from kirin.dialects.ilist.stmts import IListType
 from kirin.dialects.ilist.runtime import IList
 
+from .._dialect import dialect
 
+
+@dialect.inference
 class List2IList(RewriteRule):
 
     def rewrite_Block(self, node: ir.Block) -> RewriteResult:

--- a/src/kirin/dialects/ilist/rewrite/list.py
+++ b/src/kirin/dialects/ilist/rewrite/list.py
@@ -8,7 +8,7 @@ from kirin.dialects.ilist.runtime import IList
 from .._dialect import dialect
 
 
-@dialect.inference
+@dialect.post_inference
 class List2IList(RewriteRule):
 
     def rewrite_Block(self, node: ir.Block) -> RewriteResult:

--- a/src/kirin/dialects/ilist/rewrite/unroll.py
+++ b/src/kirin/dialects/ilist/rewrite/unroll.py
@@ -10,7 +10,7 @@ from kirin.dialects.py.indexing import GetItem
 from .._dialect import dialect
 
 
-@dialect.inference
+@dialect.post_inference
 class Unroll(RewriteRule):
 
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:

--- a/src/kirin/dialects/ilist/rewrite/unroll.py
+++ b/src/kirin/dialects/ilist/rewrite/unroll.py
@@ -7,7 +7,10 @@ from kirin.dialects.ilist.stmts import Map, New, Scan, Foldl, Foldr, ForEach, IL
 from kirin.dialects.py.constant import Constant
 from kirin.dialects.py.indexing import GetItem
 
+from .._dialect import dialect
 
+
+@dialect.inference
 class Unroll(RewriteRule):
 
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:

--- a/src/kirin/dialects/scf/trim.py
+++ b/src/kirin/dialects/scf/trim.py
@@ -3,8 +3,10 @@ from kirin.rewrite.abc import RewriteRule
 from kirin.rewrite.result import RewriteResult
 
 from .stmts import For, Yield, IfElse
+from ._dialect import dialect
 
 
+@dialect.canonicalize
 class UnusedYield(RewriteRule):
     """Trim unused results from `For` and `IfElse` statements."""
 

--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -12,8 +12,17 @@ T = TypeVar("T")
 
 if TYPE_CHECKING:
     from kirin.types import PyClass
+    from kirin.rewrite.abc import RewriteRule
     from kirin.interp.table import MethodTable
     from kirin.lowering.python.dialect import FromPythonAST
+
+
+@dataclass
+class Rules:
+    canonicalize: list[RewriteRule] = field(default_factory=list, init=True)
+    """A collection of rules for Canonicalize pass."""
+    inference: list[RewriteRule] = field(default_factory=list, init=True)
+    """A collection of rules for Inference pass."""
 
 
 # TODO: add an option to generate default lowering at dialect construction
@@ -40,6 +49,8 @@ class Dialect:
     """A dictionary of registered method table in the dialect."""
     lowering: dict[str, FromPythonAST] = field(default_factory=dict, init=True)
     """A dictionary of registered python lowering implmentations in the dialect."""
+    rules: Rules = field(default_factory=Rules, init=True)
+    """A collection of rewrite rules for the dialect."""
     python_types: dict[tuple[str, str], "PyClass"] = field(
         default_factory=dict, init=True
     )
@@ -152,3 +163,23 @@ class Dialect:
 
         else:
             raise ValueError(f"Cannot register {node} to Dialect")
+
+    def canonicalize(self, rule: type[RewriteRule]) -> type[RewriteRule]:
+        """Register a rewrite rule to the canonicalization pass.
+
+        Args:
+            rule (RewriteRule): The rewrite rule to register.
+        """
+        self.rules.canonicalize.append(rule())
+        return rule
+
+    def inference(self, rule: type[RewriteRule]) -> type[RewriteRule]:
+        """Register a rewrite rule to the inference pass.
+        Usually, this is used to register a rule that requires
+        type inference to be run first.
+
+        Args:
+            rule (RewriteRule): The rewrite rule to register.
+        """
+        self.rules.inference.append(rule())
+        return rule

--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -173,7 +173,7 @@ class Dialect:
         self.rules.canonicalize.append(rule())
         return rule
 
-    def inference(self, rule: type[RewriteRule]) -> type[RewriteRule]:
+    def post_inference(self, rule: type[RewriteRule]) -> type[RewriteRule]:
         """Register a rewrite rule to the inference pass.
         Usually, this is used to register a rule that requires
         type inference to be run first.

--- a/src/kirin/passes/canonicalize.py
+++ b/src/kirin/passes/canonicalize.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from kirin.ir.method import Method
+from kirin.rewrite.abc import RewriteResult
+
+from .abc import Pass
+
+
+@dataclass
+class Canonicalize(Pass):
+
+    def unsafe_run(self, mt: Method) -> RewriteResult:
+        result = RewriteResult()
+        for dialect in self.dialects:
+            for rule in dialect.rules.canonicalize:
+                result = rule.rewrite(mt.code).join(result)
+        return result

--- a/src/kirin/passes/default.py
+++ b/src/kirin/passes/default.py
@@ -1,6 +1,5 @@
 from dataclasses import field, dataclass
 
-from kirin.dialects import ilist
 from kirin.ir.method import Method
 from kirin.passes.fold import Fold
 from kirin.rewrite.abc import RewriteResult
@@ -9,6 +8,7 @@ from kirin.passes.aggressive import Fold as AggressiveFold
 from .abc import Pass
 from .typeinfer import TypeInfer
 from .hint_const import HintConst
+from .canonicalize import Canonicalize
 
 
 @dataclass
@@ -18,15 +18,16 @@ class Default(Pass):
     aggressive: bool = field(default=False, kw_only=True)
     typeinfer: bool = field(default=True, kw_only=True)
 
+    canonicalize: Canonicalize = field(init=False)
     hint_const_pass: HintConst = field(init=False)
     typeinfer_pass: TypeInfer = field(init=False)
-    ilist_desugar: ilist.IListDesugar = field(init=False)
     fold_pass: Pass = field(init=False)
 
     def __post_init__(self):
         # TODO: cleanup no_raise
-        self.ilist_desugar = ilist.IListDesugar(self.dialects, no_raise=self.no_raise)
         self.typeinfer_pass = TypeInfer(self.dialects, no_raise=self.no_raise)
+        self.canonicalize = Canonicalize(self.dialects, no_raise=self.no_raise)
+
         self.hint_const_pass = HintConst(self.dialects, no_raise=self.no_raise)
         if self.aggressive:
             self.fold_pass = AggressiveFold(self.dialects, no_raise=self.no_raise)
@@ -37,13 +38,13 @@ class Default(Pass):
         if self.verify:
             mt.verify()
 
-        result = self.ilist_desugar.fixpoint(mt)
+        result = self.canonicalize.fixpoint(mt)
         if self.typeinfer:
-            self.typeinfer_pass(mt).join(result)
+            result = self.typeinfer_pass(mt).join(result)
 
         if self.fold:
             if self.aggressive:
-                self.fold_pass.fixpoint(mt).join(result)
+                result = self.fold_pass.fixpoint(mt).join(result)
             else:
-                self.fold_pass(mt).join(result)
+                result = self.fold_pass(mt).join(result)
         return result

--- a/src/kirin/passes/post_inference.py
+++ b/src/kirin/passes/post_inference.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from kirin.ir.method import Method
+from kirin.rewrite.abc import RewriteResult
+
+from .abc import Pass
+
+
+@dataclass
+class PostInference(Pass):
+
+    def unsafe_run(self, mt: Method) -> RewriteResult:
+        result = RewriteResult()
+        for dialect in self.dialects:
+            for rule in dialect.rules.inference:
+                result = rule.rewrite(mt.code).join(result)
+        return result

--- a/src/kirin/passes/typeinfer.py
+++ b/src/kirin/passes/typeinfer.py
@@ -8,19 +8,20 @@ from kirin.dialects.func import Signature
 from kirin.analysis.typeinfer import TypeInference
 from kirin.rewrite.apply_type import ApplyType
 from kirin.rewrite.type_assert import InlineTypeAssert
-from kirin.dialects.ilist.rewrite import HintLen
 
 from .hint_const import HintConst
+from .post_inference import PostInference
 
 
 @dataclass
 class TypeInfer(Pass):
     hint_const: HintConst = field(init=False)
+    inference: PostInference = field(init=False)
 
     def __post_init__(self):
         self.infer = TypeInference(self.dialects)
-        self.hint_const = HintConst(self.dialects)
-        self.hint_const.no_raise = self.no_raise
+        self.hint_const = HintConst(self.dialects, no_raise=self.no_raise)
+        self.post_inference = PostInference(self.dialects, no_raise=self.no_raise)
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
         result = self.hint_const.unsafe_run(mt)
@@ -33,10 +34,11 @@ class TypeInfer(Pass):
         result = (
             Chain(
                 Walk(ApplyType(frame.entries)),
-                Walk(Chain(InlineTypeAssert(), HintLen())),
+                Walk(InlineTypeAssert()),
             )
             .rewrite(mt.code)
             .join(result)
         )
+        result = self.post_inference.fixpoint(mt).join(result)
         mt.inferred = True
         return result


### PR DESCRIPTION
this adds two hook to the `Dialect` object, which allow users to register two kind of rewrite rule that will be triggered 

a) Canonicalization: before running all other passes 
b) PostInference: after running type inference

this decouples some of the rules and now we don't need to import them inside the `kirin.passes` module anymore.