### PR TITLE
feat: improve error message of calling class method

### DIFF
--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -85,6 +85,9 @@ class Call(ir.Statement):
                     help="did you try to call a Python class method within a kernel? "
                     "consider rewriting it with a captured variable instead of calling it inside the kernel",
                 )
+
+            if self.callee.type is types.Any:
+                return
             raise ir.TypeCheckError(
                 self,
                 f"callee must be a method type, got {self.callee.type}",

--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -1,3 +1,5 @@
+from types import MethodType as ClassMethodType, FunctionType
+
 from kirin import ir, types
 from kirin.decl import info, statement
 from kirin.print.printer import Printer
@@ -68,12 +70,20 @@ class Call(ir.Statement):
 
     def check_type(self) -> None:
         if not self.callee.type.is_subseteq(types.MethodType):
-            if self.callee.type.is_subseteq(types.PyClass(type(lambda x: x))):
+            if self.callee.type.is_subseteq(types.PyClass(FunctionType)):
                 raise ir.TypeCheckError(
                     self,
                     f"callee must be a method type, got {self.callee.type}",
                     help="did you call a Python function directly? "
                     "consider decorating it with kernel decorator",
+                )
+
+            if self.callee.type.is_subseteq(types.PyClass(ClassMethodType)):
+                raise ir.TypeCheckError(
+                    self,
+                    "callee must be a method type, got class method",
+                    help="did you try to call a Python class method within a kernel? "
+                    "consider rewriting it with a captured variable instead of calling it inside the kernel",
                 )
             raise ir.TypeCheckError(
                 self,

--- a/src/kirin/ir/method.py
+++ b/src/kirin/ir/method.py
@@ -39,9 +39,6 @@ class Method(Printable, typing.Generic[Param, RetType]):
     inferred: bool = False
     """if typeinfer has been run on this method
     """
-    verified: bool = False
-    """if `code.verify` has been run on this method
-    """
 
     def __hash__(self) -> int:
         return id(self)
@@ -99,30 +96,23 @@ class Method(Printable, typing.Generic[Param, RetType]):
             self.fields,
             self.file,
             self.inferred,
-            self.verified,
         )
 
     def verify(self) -> None:
         """verify the method body.
 
         This will raise a ValidationError if the method body is not valid.
-        This will also set the `verified` attribute to True.
         """
         try:
             self.code.verify()
         except ValidationError as e:
             self.__postprocess_validation_error(e)
-        self.verified = True
 
     def verify_type(self) -> None:
         """verify the method type.
 
         This will raise a ValidationError if the method type is not valid.
-        This will also set the `verified` attribute to True.
         """
-        if self.verified:
-            return
-
         # NOTE: verify the method body
         self.verify()
 

--- a/src/kirin/lowering/python/lowering.py
+++ b/src/kirin/lowering/python/lowering.py
@@ -202,7 +202,7 @@ class Python(LoweringABC[ast.AST]):
             # symbol exist in global, but not ir.Statement, not found in locals either
             # this means the symbol is referring to an external uncallable object
             # try to hint the user
-            if inspect.isfunction(global_callee):
+            if inspect.isfunction(global_callee) or inspect.ismethod(global_callee):
                 raise BuildError(
                     f"unsupported callee: {repr(global_callee)}."
                     "Are you trying to call a python function? This is not supported."

--- a/src/kirin/passes/default.py
+++ b/src/kirin/passes/default.py
@@ -13,7 +13,7 @@ from .canonicalize import Canonicalize
 
 @dataclass
 class Default(Pass):
-    verify: bool = field(default=False, kw_only=True)
+    verify: bool = field(default=True, kw_only=True)
     fold: bool = field(default=True, kw_only=True)
     aggressive: bool = field(default=False, kw_only=True)
     typeinfer: bool = field(default=True, kw_only=True)
@@ -41,6 +41,8 @@ class Default(Pass):
         result = self.canonicalize.fixpoint(mt)
         if self.typeinfer:
             result = self.typeinfer_pass(mt).join(result)
+            if self.verify:
+                mt.verify_type()
 
         if self.fold:
             if self.aggressive:

--- a/src/kirin/prelude.py
+++ b/src/kirin/prelude.py
@@ -152,7 +152,7 @@ def basic(self):
             Doc(
                 "run type inference and apply the inferred type to IR, default `False`"
             ),
-        ] = True,
+        ] = False,
         fold: Annotated[bool, Doc("run folding passes")] = True,
         aggressive: Annotated[
             bool, Doc("run aggressive folding passes if `fold=True`")

--- a/src/kirin/prelude.py
+++ b/src/kirin/prelude.py
@@ -152,7 +152,7 @@ def basic(self):
             Doc(
                 "run type inference and apply the inferred type to IR, default `False`"
             ),
-        ] = False,
+        ] = True,
         fold: Annotated[bool, Doc("run folding passes")] = True,
         aggressive: Annotated[
             bool, Doc("run aggressive folding passes if `fold=True`")

--- a/src/kirin/source.py
+++ b/src/kirin/source.py
@@ -1,4 +1,5 @@
 import ast
+import math
 import shutil
 import textwrap
 from dataclasses import dataclass
@@ -135,7 +136,8 @@ class SourceInfo:
         ret = " " * indent + "[red]" + ret
         if help:
             hint_indent = len(ret) - len("[ret]") + len(" help: ")
-            terminal_width = shutil.get_terminal_size().columns - hint_indent - 40
+            terminal_width = math.floor(shutil.get_terminal_size().columns * 0.7)
+            terminal_width = max(terminal_width - hint_indent, 10)
             wrapped = textwrap.fill(str(help), width=terminal_width)
             lines = wrapped.splitlines()
             ret += " help: " + lines[0] + "[/red]"

--- a/src/kirin/source.py
+++ b/src/kirin/source.py
@@ -1,4 +1,6 @@
 import ast
+import shutil
+import textwrap
 from dataclasses import dataclass
 
 from rich.console import Console
@@ -132,7 +134,21 @@ class SourceInfo:
 
         ret = " " * indent + "[red]" + ret
         if help:
-            ret += " help: " + str(help) + "[/red]"
+            hint_indent = len(ret) - len("[ret]") + len(" help: ")
+            terminal_width = shutil.get_terminal_size().columns - hint_indent - 40
+            wrapped = textwrap.fill(str(help), width=terminal_width)
+            lines = wrapped.splitlines()
+            ret += " help: " + lines[0] + "[/red]"
+            for line in lines[1:]:
+                ret += (
+                    "\n"
+                    + " " * (error_lineno_len + indent)
+                    + "[dim]│[/dim]"
+                    + " " * hint_indent
+                    + "[red]"
+                    + line
+                    + "[/red]"
+                )
         if show_lineno:
             ret = " " * error_lineno_len + "[dim]│[/dim]" + ret
         return ret

--- a/test/program/py/test_class.py
+++ b/test/program/py/test_class.py
@@ -1,0 +1,29 @@
+import pytest
+
+from kirin.prelude import basic
+
+
+class Foo:
+
+    def some_kernel(self):
+        @basic(verify=False)
+        def goo(x: int):
+            return x
+
+        return goo
+
+    def another_kernel(self):
+        @basic(verify=False)
+        def goo(x: int):
+            kernel = self.some_kernel()
+            kernel(x)
+
+        return goo
+
+
+def test_call_method_error():
+    foo = Foo()
+    goo = foo.another_kernel()
+
+    with pytest.raises(Exception):
+        goo.verify_type()


### PR DESCRIPTION
this PR improves the error printing and error message when calling a class method

for example

```python
from kirin.prelude import basic


class Foo:

    def some_kernel(self):
        @basic
        def goo(x: int):
            return x

        return goo

    def another_kernel(self):
        @basic
        def goo(x: int):
            kernel = self.some_kernel()
            kernel(x)
        return goo


foo = Foo()
goo = foo.another_kernel()
goo.print()
goo.verify_type()
```

produces

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/4d0c220d-19f0-45fa-be17-fcceb1327631" />
