### PR TITLE
support stacktrace in interpreter

### DIFF
--- a/src/kirin/analysis/forward.py
+++ b/src/kirin/analysis/forward.py
@@ -64,7 +64,7 @@ class ForwardExtra(
         sys.setrecursionlimit(self.max_python_recursion_depth)
         try:
             frame, ret = self.run_method(method, args)
-        except interp.InterpreterError as e:
+        except Exception as e:
             # NOTE: initialize will create new State
             # so we don't need to copy the frames.
             if not no_raise:

--- a/src/kirin/exception.py
+++ b/src/kirin/exception.py
@@ -2,6 +2,7 @@
 for the Kirin-based compilers.
 """
 
+import abc
 import sys
 import types
 
@@ -10,6 +11,12 @@ stacktrace = False
 
 class NoPythonStackTrace(Exception):
     pass
+
+
+class CustomStackTrace(Exception):
+
+    @abc.abstractmethod
+    def print_stacktrace(self) -> None: ...
 
 
 def enable_stracetrace():
@@ -28,6 +35,11 @@ def exception_handler(exc_type, exc_value, exc_tb: types.TracebackType):
     """Custom exception handler to format and print exceptions."""
     if not stacktrace and issubclass(exc_type, NoPythonStackTrace):
         print(exc_value, file=sys.stderr)
+        return
+
+    if not stacktrace and issubclass(exc_type, CustomStackTrace):
+        # Handle custom stack trace exceptions
+        exc_value.print_stacktrace()
         return
 
     # Call the default exception handler

--- a/src/kirin/interp/__init__.py
+++ b/src/kirin/interp/__init__.py
@@ -34,6 +34,7 @@ from .abstract import (
 from .concrete import Interpreter as Interpreter
 from .exceptions import (
     WrapException as WrapException,
+    IntepreterExit as IntepreterExit,
     InterpreterError as InterpreterError,
     FuelExhaustedError as FuelExhaustedError,
 )

--- a/src/kirin/interp/exceptions.py
+++ b/src/kirin/interp/exceptions.py
@@ -1,4 +1,14 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
+
+from kirin.exception import CustomStackTrace
+
+if TYPE_CHECKING:
+    from .frame import FrameABC
+    from .state import InterpreterState
 
 
 # errors
@@ -18,6 +28,27 @@ class WrapException(InterpreterError):
     """A special interpreter error that wraps a Python exception."""
 
     exception: Exception
+
+
+@dataclass
+class IntepreterExit(CustomStackTrace):
+    exception: Exception
+    state: InterpreterState
+
+    def print_stacktrace(self) -> None:
+        """Print the stacktrace of the interpreter."""
+        frame: FrameABC | None = self.state.current_frame
+        print(f"{type(self.exception).__name__}: {self.exception}", file=sys.stderr)
+        print("Traceback (most recent call last):", file=sys.stderr)
+        frames: list[FrameABC] = []
+        while frame is not None:
+            frames.append(frame)
+            frame = frame.parent
+        frames.reverse()
+        for frame in frames:
+            if stmt := frame.current_stmt:
+                print("  " + repr(stmt.source), file=sys.stderr)
+                print("     " + stmt.print_str(end=""), file=sys.stderr)
 
 
 class FuelExhaustedError(InterpreterError):

--- a/src/kirin/interp/frame.py
+++ b/src/kirin/interp/frame.py
@@ -34,6 +34,8 @@ class FrameABC(ABC, Generic[ValueType]):
     has_parent_access: bool = field(default=False, kw_only=True, compare=True)
     """If we have access to the entries of the parent frame."""
 
+    lineno_offset: int = field(default=0, kw_only=True, compare=True)
+
     current_stmt: Statement | None = field(
         default=None, init=False, compare=False, repr=False
     )

--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -190,15 +190,15 @@ class DialectGroup(Generic[PassParams]):
         Returns:
             Method: the method created from the python function.
         """
+        frame = inspect.currentframe()
 
         def wrapper(py_func: Callable) -> Method:
             if py_func.__name__ == "<lambda>":
                 raise ValueError("Cannot compile lambda functions")
 
             lineno_offset, file = 0, ""
-            frame = inspect.currentframe()
-            if frame and frame.f_back is not None and frame.f_back.f_back is not None:
-                call_site_frame = frame.f_back.f_back
+            if frame and frame.f_back is not None:
+                call_site_frame = frame.f_back
                 if py_func.__name__ in call_site_frame.f_locals:
                     raise CompilerError(
                         f"overwriting function definition of `{py_func.__name__}`"

--- a/src/kirin/ir/method.py
+++ b/src/kirin/ir/method.py
@@ -50,7 +50,7 @@ class Method(Printable, typing.Generic[Param, RetType]):
             raise ValueError("Incorrect number of arguments")
         # NOTE: multi-return values will be wrapped in a tuple for Python
         interp = Interpreter(self.dialects)
-        return interp.run(self, args=args, kwargs=kwargs).expect()
+        return interp.run(self, args=args, kwargs=kwargs)
 
     @property
     def args(self):
@@ -141,7 +141,6 @@ class Method(Printable, typing.Generic[Param, RetType]):
                 source.splitlines(),
                 e,
                 file=self.file,
-                lineno_offset=self.lineno_offset,
             )
         else:
             msg += "\nNo source available"

--- a/src/kirin/lowering/python/lowering.py
+++ b/src/kirin/lowering/python/lowering.py
@@ -112,7 +112,7 @@ class Python(LoweringABC[ast.AST]):
         source = source or ast.unparse(stmt)
         state = State(
             self,
-            source=SourceInfo.from_ast(stmt, lineno_offset, col_offset),
+            source=SourceInfo.from_ast(stmt, lineno_offset, col_offset, file),
             file=file,
             lines=source.splitlines(),
             lineno_offset=lineno_offset,
@@ -156,7 +156,7 @@ class Python(LoweringABC[ast.AST]):
     def visit(self, state: State[ast.AST], node: ast.AST) -> Result:
         if hasattr(node, "lineno"):
             state.source = SourceInfo.from_ast(
-                node, state.lineno_offset, state.col_offset
+                node, state.lineno_offset, state.col_offset, state.file
             )
         name = node.__class__.__name__
         if name in self.registry.ast_table:
@@ -169,7 +169,7 @@ class Python(LoweringABC[ast.AST]):
     def visit_Call(self, state: State[ast.AST], node: ast.Call) -> Result:
         if hasattr(node.func, "lineno"):
             state.source = SourceInfo.from_ast(
-                node.func, state.lineno_offset, state.col_offset
+                node.func, state.lineno_offset, state.col_offset, state.file
             )
 
         global_callee_result = state.get_global(node.func, no_raise=True)

--- a/src/kirin/lowering/state.py
+++ b/src/kirin/lowering/state.py
@@ -228,5 +228,4 @@ class State(Generic[ASTNodeType]):
             indent=indent,
             show_lineno=show_lineno,
             max_lines=max_lines,
-            lineno_offset=self.lineno_offset,
         )

--- a/test/emit/test_julia.py
+++ b/test/emit/test_julia.py
@@ -8,7 +8,7 @@ from kirin.emit.julia import EmitJulia
 def emit(fn: ir.Method):
     with io.StringIO() as file:
         emit_ = EmitJulia(basic_no_opt, file)
-        emit_.run(fn, tuple(fn.arg_names[1:])).expect()
+        emit_.run(fn, tuple(fn.arg_names[1:]))
         return file.getvalue()
 
 

--- a/test/interp/test_func.py
+++ b/test/interp/test_func.py
@@ -1,6 +1,7 @@
 import pytest
 
 from kirin.prelude import basic_no_opt
+from kirin.interp.exceptions import IntepreterExit
 
 
 def test_basic():
@@ -60,7 +61,7 @@ def test_assert():
     assert multi(0) == 1
     assert multi(1) is None
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(IntepreterExit):
         multi(2)
 
 

--- a/test/interp/test_select.py
+++ b/test/interp/test_select.py
@@ -42,5 +42,5 @@ def main(x):
 
 def test_interp():
     interp_ = DummyInterpreter(basic)
-    with pytest.raises(interp.InterpreterError):
-        interp_.run(main, (EmptyLattice(),)).expect()
+    with pytest.raises(interp.IntepreterExit):
+        interp_.run(main, (EmptyLattice(),))

--- a/test/program/py/aha/gaga.py
+++ b/test/program/py/aha/gaga.py
@@ -7,9 +7,6 @@ def foo(x: int) -> int:
     return x + 1
 
 
-foo.code.print()
-
-
 @basic_no_opt
 def goo(x: int) -> int:
     return x + 1

--- a/test/program/py/test_basic.py
+++ b/test/program/py/test_basic.py
@@ -4,6 +4,7 @@ import pytest
 # composite modules
 from aha import gaga, hoho
 
+from kirin.interp import IntepreterExit
 from kirin.prelude import basic_no_opt
 
 
@@ -137,7 +138,7 @@ def test_add(x):
     if x == 1:
         assert add(x) == (x + 1) + (x + 1) + (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: add(x))
+        pytest.raises(IntepreterExit, lambda: add(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -145,7 +146,7 @@ def test_sub(x):
     if x == 1:
         assert sub(x) == (x + 1) - (x + 1) - (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: sub(x))
+        pytest.raises(IntepreterExit, lambda: sub(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -153,7 +154,7 @@ def test_mul(x):
     if x == 1:
         assert mul(x) == (x + 1) * (x + 1) * (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: mul(x))
+        pytest.raises(IntepreterExit, lambda: mul(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -161,7 +162,7 @@ def test_div(x):
     if x == 1:
         assert div(x) == (x + 1) / (x + 1) / (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: div(x))
+        pytest.raises(IntepreterExit, lambda: div(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -169,7 +170,7 @@ def test_floordiv(x):
     if x == 1:
         assert floordiv(x) == (x + 1) // (x + 1) // (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: floordiv(x))
+        pytest.raises(IntepreterExit, lambda: floordiv(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -177,7 +178,7 @@ def test_mod(x):
     if x == 1:
         assert mod(x) == (x + 1) % (x + 1) % (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: mod(x))
+        pytest.raises(IntepreterExit, lambda: mod(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -185,7 +186,7 @@ def test_pow(x):
     if x == 1:
         assert pow(x) == (x + 1) ** (x + 1) ** (x + 1)
     else:
-        pytest.raises(AssertionError, lambda: pow(x))
+        pytest.raises(IntepreterExit, lambda: pow(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -193,7 +194,7 @@ def test_eq(x):
     if x == 1:
         assert eq(x) == ((x + 1) == (x + 1) == (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: eq(x))
+        pytest.raises(IntepreterExit, lambda: eq(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -201,7 +202,7 @@ def test_ne(x):
     if x == 1:
         assert ne(x) == ((x + 1) != (x + 1) != (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: ne(x))
+        pytest.raises(IntepreterExit, lambda: ne(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -209,7 +210,7 @@ def test_lt(x):
     if x == 1:
         assert lt(x) == ((x + 1) < (x + 1) < (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: lt(x))
+        pytest.raises(IntepreterExit, lambda: lt(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -217,7 +218,7 @@ def test_le(x):
     if x == 1:
         assert le(x) == ((x + 1) <= (x + 1) <= (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: le(x))
+        pytest.raises(IntepreterExit, lambda: le(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -225,7 +226,7 @@ def test_gt(x):
     if x == 1:
         assert gt(x) == ((x + 1) > (x + 1) > (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: gt(x))
+        pytest.raises(IntepreterExit, lambda: gt(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -233,7 +234,7 @@ def test_ge(x):
     if x == 1:
         assert ge(x) == ((x + 1) >= (x + 1) >= (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: ge(x))
+        pytest.raises(IntepreterExit, lambda: ge(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -241,7 +242,7 @@ def test_and(x):
     if x == 1:
         assert and_(x) == ((x + 1) and (x + 1) and (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: and_(x))
+        pytest.raises(IntepreterExit, lambda: and_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -249,7 +250,7 @@ def test_or(x):
     if x == 1:
         assert or_(x) == ((x + 1) or (x + 1) or (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: or_(x))
+        pytest.raises(IntepreterExit, lambda: or_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -257,7 +258,7 @@ def test_and_or(x):
     if x == 1:
         assert and_or(x) == ((x + 1) and (x + 1) or (x + 1))
     else:
-        pytest.raises(AssertionError, lambda: and_or(x))
+        pytest.raises(IntepreterExit, lambda: and_or(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -265,7 +266,7 @@ def test_not(x):
     if x == 1:
         assert not_(x) == (not ((x + 1) == (x + 1) == (x + 1)))
     else:
-        pytest.raises(AssertionError, lambda: not_(x))
+        pytest.raises(IntepreterExit, lambda: not_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])


### PR DESCRIPTION
```python
from kirin.prelude import basic

@basic(typeinfer=True)
def some_code_will_error(x):
    """
    This function will raise an error.
    """
    return 1 / x

@basic(typeinfer=True)
def some_func():
    return some_code_will_error(0)

some_func()
```

<img width="839" alt="image" src="https://github.com/user-attachments/assets/031700a6-87f7-4d72-bc54-a11871c66e64" />
