### PR TITLE
rework error handling in compiler

### DIFF
--- a/src/kirin/dialects/py/assertion.py
+++ b/src/kirin/dialects/py/assertion.py
@@ -66,9 +66,9 @@ class Concrete(interp.MethodTable):
             return ()
 
         if stmt.message:
-            raise interp.WrapException(AssertionError(frame.get(stmt.message)))
+            raise AssertionError(frame.get(stmt.message))
         else:
-            raise interp.WrapException(AssertionError("Assertion failed"))
+            raise AssertionError("Assertion failed")
 
 
 @dialect.register(key="typeinfer")

--- a/src/kirin/dialects/py/assign.py
+++ b/src/kirin/dialects/py/assign.py
@@ -99,9 +99,7 @@ class Concrete(interp.MethodTable):
         got = frame.get(stmt.got)
         got_type = types.PyClass(type(got))
         if not got_type.is_subseteq(stmt.expected):
-            raise interp.WrapException(
-                TypeError(f"Expected {stmt.expected}, got {got_type}")
-            )
+            raise TypeError(f"Expected {stmt.expected}, got {got_type}")
         return (frame.get(stmt.got),)
 
 

--- a/src/kirin/exception.py
+++ b/src/kirin/exception.py
@@ -2,44 +2,176 @@
 for the Kirin-based compilers.
 """
 
-import abc
+from __future__ import annotations
+
+import os
 import sys
+import math
 import types
+import shutil
+import textwrap
+from typing import TYPE_CHECKING
 
-stacktrace = False
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from kirin import interp
+    from kirin.source import SourceInfo
+
+KIRIN_INTERP_STATE = "__kirin_interp_state"
+KIRIN_PYTHON_STACKTRACE = os.environ.get("KIRIN_PYTHON_STACKTRACE", "0") == "1"
+KIRIN_STATIC_CHECK_LINENO = os.environ.get("KIRIN_STATIC_CHECK_LINENO", "1") == "1"
+KIRIN_STATIC_CHECK_INDENT = int(os.environ.get("KIRIN_STATIC_CHECK_INDENT", "2"))
+KIRIN_STATIC_CHECK_MAX_LINES = int(os.environ.get("KIRIN_STATIC_CHECK_MAX_LINES", "3"))
 
 
-class NoPythonStackTrace(Exception):
-    pass
+class StaticCheckError(Exception):
+    def __init__(self, *messages: str, help: str | None = None) -> None:
+        super().__init__(*messages)
+        self.help: str | None = help
+        self.source: SourceInfo | None = None
+        self.lines: list[str] | None = None
+        self.indent: int = KIRIN_STATIC_CHECK_INDENT
+        self.max_lines: int = KIRIN_STATIC_CHECK_MAX_LINES
+        self.show_lineno: bool = KIRIN_STATIC_CHECK_LINENO
 
+    def hint(self):
+        help = self.help or ""
+        source = self.source or SourceInfo(0, 0, 0, 0)
+        lines = self.lines or []
+        begin = max(0, source.lineno - self.max_lines)
+        end = max(
+            max(source.lineno + self.max_lines, source.end_lineno or 1),
+            1,
+        )
+        end = min(len(lines), end)  # make sure end is within bounds
+        lines = lines[begin:end]
+        error_lineno = source.lineno + source.lineno_begin
+        error_lineno_len = len(str(error_lineno))
+        code_indent = min(map(self.__get_indent, lines), default=0)
 
-class CustomStackTrace(Exception):
+        console = Console(force_terminal=True)
+        with console.capture() as capture:
+            console.print(
+                f"  {source or 'stdin'}",
+                markup=True,
+                highlight=False,
+            )
+            for lineno, line in enumerate(lines, begin):
+                line = " " * self.indent + line[code_indent:]
+                if self.show_lineno:
+                    if lineno + 1 == source.lineno:
+                        line = f"{error_lineno}[dim]│[/dim]" + line
+                    else:
+                        line = "[dim]" + " " * (error_lineno_len) + "│[/dim]" + line
+                console.print("  " + line, markup=True, highlight=False)
+                if lineno + 1 == source.lineno:
+                    console.print(
+                        "  "
+                        + self.__arrow(
+                            source,
+                            code_indent,
+                            error_lineno_len,
+                            help,
+                            self.indent,
+                            self.show_lineno,
+                        ),
+                        markup=True,
+                        highlight=False,
+                    )
+        return capture.get()
 
-    @abc.abstractmethod
-    def print_stacktrace(self) -> None: ...
+    def __arrow(
+        self,
+        source: SourceInfo,
+        code_indent: int,
+        error_lineno_len: int,
+        help,
+        indent: int,
+        show_lineno: bool,
+    ) -> str:
+        ret = " " * (source.col_offset - code_indent)
+        if source.end_col_offset:
+            ret += "^" * (source.end_col_offset - source.col_offset)
+        else:
+            ret += "^"
+
+        ret = " " * indent + "[red]" + ret
+        if help:
+            hint_indent = len(ret) - len("[ret]") + len(" help: ")
+            terminal_width = math.floor(shutil.get_terminal_size().columns * 0.7)
+            terminal_width = max(terminal_width - hint_indent, 10)
+            wrapped = textwrap.fill(str(help), width=terminal_width)
+            lines = wrapped.splitlines()
+            ret += " help: " + lines[0] + "[/red]"
+            for line in lines[1:]:
+                ret += (
+                    "\n"
+                    + " " * (error_lineno_len + indent)
+                    + "[dim]│[/dim]"
+                    + " " * hint_indent
+                    + "[red]"
+                    + line
+                    + "[/red]"
+                )
+        if show_lineno:
+            ret = " " * error_lineno_len + "[dim]│[/dim]" + ret
+        return ret
+
+    @staticmethod
+    def __get_indent(line: str) -> int:
+        if len(line) == 0:
+            return int(1e9)  # very large number
+        return len(line) - len(line.lstrip())
 
 
 def enable_stracetrace():
     """Enable the stacktrace for all exceptions."""
-    global stacktrace
-    stacktrace = True
+    global KIRIN_PYTHON_STACKTRACE
+    KIRIN_PYTHON_STACKTRACE = True
 
 
 def disable_stracetrace():
     """Disable the stacktrace for all exceptions."""
-    global stacktrace
-    stacktrace = False
+    global KIRIN_PYTHON_STACKTRACE
+    KIRIN_PYTHON_STACKTRACE = False
+
+
+def print_stacktrace(exception: Exception, state: interp.InterpreterState):
+    frame: interp.FrameABC | None = state.current_frame
+    print(
+        "==== Python stacktrace has been disabled for simplicity, set KIRIN_PYTHON_STACKTRACE=1 to enable it ===="
+    )
+    print(f"{type(exception).__name__}: {exception}", file=sys.stderr)
+    print("Traceback (most recent call last):", file=sys.stderr)
+    frames: list[interp.FrameABC] = []
+    while frame is not None:
+        frames.append(frame)
+        frame = frame.parent
+    frames.reverse()
+    for frame in frames:
+        if stmt := frame.current_stmt:
+            print("  " + repr(stmt.source), file=sys.stderr)
+            print("     " + stmt.print_str(end=""), file=sys.stderr)
 
 
 def exception_handler(exc_type, exc_value, exc_tb: types.TracebackType):
     """Custom exception handler to format and print exceptions."""
-    if not stacktrace and issubclass(exc_type, NoPythonStackTrace):
-        print("".join(msg for msg in exc_value.args), file=sys.stderr)
+    if not KIRIN_PYTHON_STACKTRACE and issubclass(exc_type, StaticCheckError):
+        console = Console(force_terminal=True)
+        with console.capture() as capture:
+            console.print(f"[bold red]{exc_type.__name__}:[/bold red]", end="")
+        print(capture.get(), *exc_value.args, file=sys.stderr)
+        print("Source Traceback:", file=sys.stderr)
+        print(exc_value.hint(), file=sys.stderr, end="")
         return
 
-    if not stacktrace and issubclass(exc_type, CustomStackTrace):
+    if (
+        not KIRIN_PYTHON_STACKTRACE
+        and (state := getattr(exc_value, KIRIN_INTERP_STATE, None)) is not None
+    ):
         # Handle custom stack trace exceptions
-        exc_value.print_stacktrace()
+        print_stacktrace(exc_value, state)
         return
 
     # Call the default exception handler
@@ -51,7 +183,7 @@ sys.excepthook = exception_handler
 
 
 def custom_exc(shell, etype, evalue, tb, tb_offset=None):
-    if issubclass(etype, NoPythonStackTrace):
+    if issubclass(etype, StaticCheckError):
         # Handle BuildError exceptions
         print(evalue, file=sys.stderr)
         return

--- a/src/kirin/interp/__init__.py
+++ b/src/kirin/interp/__init__.py
@@ -18,6 +18,7 @@ abstract interpreters:
 from .base import BaseInterpreter as BaseInterpreter
 from .impl import ImplDef as ImplDef, Signature as Signature, impl as impl
 from .frame import Frame as Frame, FrameABC as FrameABC
+from .state import InterpreterState as InterpreterState
 from .table import MethodTable as MethodTable
 from .value import (
     Successor as Successor,
@@ -32,8 +33,6 @@ from .abstract import (
 )
 from .concrete import Interpreter as Interpreter
 from .exceptions import (
-    WrapException as WrapException,
-    IntepreterExit as IntepreterExit,
     InterpreterError as InterpreterError,
     FuelExhaustedError as FuelExhaustedError,
 )

--- a/src/kirin/interp/exceptions.py
+++ b/src/kirin/interp/exceptions.py
@@ -1,54 +1,14 @@
 from __future__ import annotations
 
-import sys
-from typing import TYPE_CHECKING
-from dataclasses import dataclass
-
-from kirin.exception import CustomStackTrace
-
-if TYPE_CHECKING:
-    from .frame import FrameABC
-    from .state import InterpreterState
-
 
 # errors
 class InterpreterError(Exception):
     """Generic interpreter error.
 
-    This is the base class for all interpreter errors. Interpreter
-    errors will be catched by the interpreter and handled appropriately
-    as an error with stack trace (of Kirin, not Python) from the interpreter.
+    This is the base class for all interpreter errors.
     """
 
     pass
-
-
-@dataclass
-class WrapException(InterpreterError):
-    """A special interpreter error that wraps a Python exception."""
-
-    exception: Exception
-
-
-@dataclass
-class IntepreterExit(CustomStackTrace):
-    exception: Exception
-    state: InterpreterState
-
-    def print_stacktrace(self) -> None:
-        """Print the stacktrace of the interpreter."""
-        frame: FrameABC | None = self.state.current_frame
-        print(f"{type(self.exception).__name__}: {self.exception}", file=sys.stderr)
-        print("Traceback (most recent call last):", file=sys.stderr)
-        frames: list[FrameABC] = []
-        while frame is not None:
-            frames.append(frame)
-            frame = frame.parent
-        frames.reverse()
-        for frame in frames:
-            if stmt := frame.current_stmt:
-                print("  " + repr(stmt.source), file=sys.stderr)
-                print("     " + stmt.print_str(end=""), file=sys.stderr)
 
 
 class FuelExhaustedError(InterpreterError):

--- a/src/kirin/ir/__init__.py
+++ b/src/kirin/ir/__init__.py
@@ -43,7 +43,6 @@ from kirin.ir.dialect import Dialect as Dialect
 from kirin.ir.attrs.py import PyAttr as PyAttr
 from kirin.ir.attrs.abc import Attribute as Attribute, AttributeMeta as AttributeMeta
 from kirin.ir.exception import (
-    HintedError as HintedError,
     CompilerError as CompilerError,
     TypeCheckError as TypeCheckError,
     ValidationError as ValidationError,

--- a/src/kirin/ir/exception.py
+++ b/src/kirin/ir/exception.py
@@ -1,21 +1,65 @@
+from __future__ import annotations
+
+import sys
+import inspect
+import textwrap
 from typing import TYPE_CHECKING
 
-from kirin.exception import NoPythonStackTrace
+from rich.console import Console
+
+from kirin.exception import StaticCheckError
+from kirin.print.printer import Printer
 
 if TYPE_CHECKING:
-    from kirin.ir.nodes.base import IRNode
+    from kirin.ir import IRNode, Method
 
 
-class HintedError(NoPythonStackTrace):
-    def __init__(self, *messages: str, help: str | None = None) -> None:
-        super().__init__(*messages)
-        self.help = help
-
-
-class ValidationError(HintedError):
+class ValidationError(StaticCheckError):
     def __init__(self, node: "IRNode", *messages: str, help: str | None = None) -> None:
         super().__init__(*messages, help=help)
         self.node = node
+        self.source = node.source
+        self.method: Method | None = None
+
+    def attach(self, method: Method):
+        if self.method:
+            return
+        self.method = method
+
+        from kirin.ir.nodes.stmt import Statement
+
+        console = Console(force_terminal=True, force_jupyter=False, file=sys.stderr)
+        printer = Printer(console=console)
+        # NOTE: populate the printer with the method body
+        with printer.string_io():
+            printer.print(method.code)
+        with printer.string_io() as io:
+            printer.print(self.node)
+            node_str = io.getvalue()
+
+        node_str = "\n".join(
+            map(lambda each_line: " " * 4 + each_line, node_str.splitlines())
+        )
+        if isinstance(self.node, Statement):
+            self.args += (
+                "when verifying the following statement",
+                f" `{self.node.dialect.name if self.node.dialect else "<no dialect>"}.{type(self.node).__name__}` at\n",
+                f"{node_str}\n",
+            )
+        else:
+            self.args += (
+                f"when verifying the following statement `{type(self.node).__name__}` at\n",
+                f"{node_str}\n",
+            )
+
+        if self.source:
+            self.source.lineno_begin = method.lineno_begin
+
+        if self.node.source and method.py_func:  # print hint if we have a source
+            source = textwrap.dedent(inspect.getsource(method.py_func))
+            self.lines = source.splitlines()
+            if self.source and self.source.file is None:
+                self.source.file = method.file
 
 
 class TypeCheckError(ValidationError):

--- a/src/kirin/ir/exception.py
+++ b/src/kirin/ir/exception.py
@@ -41,9 +41,10 @@ class ValidationError(StaticCheckError):
             map(lambda each_line: " " * 4 + each_line, node_str.splitlines())
         )
         if isinstance(self.node, Statement):
+            dialect = self.node.dialect.name if self.node.dialect else "<no dialect>"
             self.args += (
                 "when verifying the following statement",
-                f" `{self.node.dialect.name if self.node.dialect else "<no dialect>"}.{type(self.node).__name__}` at\n",
+                f" `{dialect}.{type(self.node).__name__}` at\n",
                 f"{node_str}\n",
             )
         else:

--- a/src/kirin/ir/nodes/block.py
+++ b/src/kirin/ir/nodes/block.py
@@ -449,7 +449,7 @@ class Block(IRNode["Region"]):
         """Verify the correctness of the Block.
 
         Raises:
-            IRValidationError: If the Block is not correct.
+            ValidationError: If the Block is not correct.
         """
         from kirin.ir.nodes.stmt import Region
 
@@ -463,7 +463,7 @@ class Block(IRNode["Region"]):
         """Verify the types of the Block.
 
         Raises:
-            IRValidationError: If the Block is not correct.
+            ValidationError: If the Block is not correct.
         """
         for stmt in self.stmts:
             stmt.verify_type()

--- a/src/kirin/ir/nodes/region.py
+++ b/src/kirin/ir/nodes/region.py
@@ -324,7 +324,7 @@ class Region(IRNode["Statement"]):
         """Verify the correctness of the Region.
 
         Raises:
-            IRValidationError: If the Region is not correct.
+            ValidationError: If the Region is not correct.
         """
         from kirin.ir.nodes.stmt import Statement
 

--- a/src/kirin/lowering/exception.py
+++ b/src/kirin/lowering/exception.py
@@ -1,9 +1,7 @@
-from kirin.exception import NoPythonStackTrace
+from kirin.exception import StaticCheckError
 
 
-class BuildError(NoPythonStackTrace):
+class BuildError(StaticCheckError):
     """Base class for all dialect lowering errors."""
 
-    def __init__(self, *msgs: object, help: str | None = None):
-        super().__init__(*msgs)
-        self.help = help
+    pass

--- a/src/kirin/lowering/python/dialect.py
+++ b/src/kirin/lowering/python/dialect.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from kirin.ir.attrs import types
 from kirin.lowering.abc import Result
 from kirin.lowering.exception import BuildError
-from kirin.lowering.python.glob import GlobalEvalError
 
 if TYPE_CHECKING:
     from kirin.lowering.state import State
@@ -84,9 +83,6 @@ class FromPythonAST(ABC):
         try:
             t = state.get_global(node).data
             return types.hint2type(t)
-        except GlobalEvalError as e:
-            state.source = e.source.offset(state.lineno_offset, state.col_offset)
-            raise e
         except Exception as e:  # noqa: E722
             raise BuildError(f"expect a type hint, got {ast.unparse(node)}") from e
 

--- a/src/kirin/lowering/python/glob.py
+++ b/src/kirin/lowering/python/glob.py
@@ -13,7 +13,7 @@ from kirin.lowering.exception import BuildError
 class GlobalEvalError(BuildError):
     """Exception raised when a global expression cannot be evaluated."""
 
-    def __init__(self, node: ast.AST, *msgs: object, help: str | None = None):
+    def __init__(self, node: ast.AST, *msgs: str, help: str | None = None):
         super().__init__(*msgs, help=help)
         self.source = SourceInfo.from_ast(node)
 

--- a/src/kirin/lowering/state.py
+++ b/src/kirin/lowering/state.py
@@ -198,34 +198,3 @@ class State(Generic[ASTNodeType]):
             yield frame
         finally:
             self.pop_frame(finalize_next)
-
-    def error_hint(
-        self,
-        e: Exception,
-        *,
-        max_lines: int = 3,
-        indent: int = 0,
-        show_lineno: bool = True,
-    ) -> str:
-        """Generate an error hint for the given error.
-        Args:
-            e (Exception): The error to generate a hint for. If the error object
-                has a `help` attribute, it will be used as the help message at the
-                location of the error.
-            max_lines (int): The maximum number of lines to show in the hint.
-            indent (int): The indentation level for the hint.
-            show_lineno (bool): Whether to show the line number in the hint.
-        Returns:
-            str: The generated error hint.
-        """
-        if self.source is None:
-            return str(e)
-
-        return self.source.error_hint(
-            self.lines,
-            e,
-            file=self.file,
-            indent=indent,
-            show_lineno=show_lineno,
-            max_lines=max_lines,
-        )

--- a/src/kirin/source.py
+++ b/src/kirin/source.py
@@ -1,10 +1,5 @@
 import ast
-import math
-import shutil
-import textwrap
 from dataclasses import dataclass
-
-from rich.console import Console
 
 
 @dataclass
@@ -14,163 +9,38 @@ class SourceInfo:
     end_lineno: int | None
     end_col_offset: int | None
     file: str | None = None
-    lineno_offset: int = 0
+    lineno_begin: int = 0
+    col_indent: int = 0
 
     @classmethod
     def from_ast(
         cls,
         node: ast.AST,
-        lineno_offset: int = 0,
-        col_offset: int = 0,
         file: str | None = None,
     ):
         end_lineno = getattr(node, "end_lineno", None)
         end_col_offset = getattr(node, "end_col_offset", None)
         return cls(
-            getattr(node, "lineno", 0) + lineno_offset,
-            getattr(node, "col_offset", 0) + col_offset,
-            end_lineno + lineno_offset if end_lineno is not None else None,
-            end_col_offset + col_offset if end_col_offset is not None else None,
+            getattr(node, "lineno", 0),
+            getattr(node, "col_offset", 0),
+            end_lineno if end_lineno is not None else None,
+            end_col_offset if end_col_offset is not None else None,
             file,
-            lineno_offset,
         )
 
-    def offset(self, lineno_offset: int = 0, col_offset: int = 0):
+    def offset(self, lineno_begin: int = 0, col_indent: int = 0):
         """Offset the source info by the given offsets.
 
         Args:
             lineno_offset (int): The line number offset.
             col_offset (int): The column offset.
         """
-        self.lineno += lineno_offset
-        self.col_offset += col_offset
-        if self.end_lineno is not None:
-            self.end_lineno += lineno_offset
-        if self.end_col_offset is not None:
-            self.end_col_offset += col_offset
-        return self
-
-    def error_hint(
-        self,
-        lines: list[str],
-        err: Exception,
-        *,
-        file: str | None = None,
-        indent: int = 2,
-        show_lineno: bool = True,
-        max_lines: int = 3,
-    ) -> str:
-        """Generate a hint for the error.
-
-        Args:
-            lines (list[str]): The lines of code.
-            err (Exception): The error to display. If the error object has a
-                `help` attribute, it will be used as the help message at the
-                location of the error.
-            file (str | None): The name of the file.
-            indent (int): The indentation level.
-            show_lineno (bool): Whether to show the line number.
-            max_lines (int): The maximum number of lines to display.
-            lineno_offset (int): The offset for the line number.
-
-        Returns:
-            str: The hint for the error.
-        """
-        help = getattr(err, "help", None)
-        begin = max(0, self.lineno - max_lines - self.lineno_offset)
-        end = max(
-            max(self.lineno + max_lines, self.end_lineno or 0) - self.lineno_offset,
-            0,
-        )
-        end = min(len(lines), end)  # make sure end is within bounds
-        lines = lines[begin:end]
-        error_lineno = self.lineno - self.lineno_offset - 1
-        error_lineno_len = len(str(self.lineno))
-        code_indent = min(map(self.__get_indent, lines), default=0)
-
-        console = Console(force_terminal=True)
-        with console.capture() as capture:
-            console.print()
-            console.print(
-                f"File: [dim]{file or 'stdin'}:{self.lineno}[/dim]",
-                markup=True,
-                highlight=False,
-            )
-            emsg = "\n  ".join(err.args)
-            console.print(f"[red]  {type(err).__name__}: {emsg}[/red]")
-            for lineno, line in enumerate(lines, begin):
-                line = " " * indent + line[code_indent:]
-                if show_lineno:
-                    if lineno == error_lineno:
-                        line = f"{self.lineno}[dim]│[/dim]" + line
-                    else:
-                        line = "[dim]" + " " * (error_lineno_len) + "│[/dim]" + line
-                console.print("  " + line, markup=True, highlight=False)
-                if lineno == error_lineno:
-                    console.print(
-                        "  "
-                        + self.__arrow(
-                            code_indent, error_lineno_len, help, indent, show_lineno
-                        ),
-                        markup=True,
-                        highlight=False,
-                    )
-
-            if end == error_lineno:
-                console.print(
-                    "  "
-                    + self.__arrow(
-                        code_indent, error_lineno_len, help, indent, show_lineno
-                    ),
-                    markup=True,
-                    highlight=False,
-                )
-
-        return capture.get()
-
-    def __arrow(
-        self,
-        code_indent: int,
-        error_lineno_len: int,
-        help,
-        indent: int,
-        show_lineno: bool,
-    ) -> str:
-        ret = " " * (self.col_offset - code_indent)
-        if self.end_col_offset:
-            ret += "^" * (self.end_col_offset - self.col_offset)
-        else:
-            ret += "^"
-
-        ret = " " * indent + "[red]" + ret
-        if help:
-            hint_indent = len(ret) - len("[ret]") + len(" help: ")
-            terminal_width = math.floor(shutil.get_terminal_size().columns * 0.7)
-            terminal_width = max(terminal_width - hint_indent, 10)
-            wrapped = textwrap.fill(str(help), width=terminal_width)
-            lines = wrapped.splitlines()
-            ret += " help: " + lines[0] + "[/red]"
-            for line in lines[1:]:
-                ret += (
-                    "\n"
-                    + " " * (error_lineno_len + indent)
-                    + "[dim]│[/dim]"
-                    + " " * hint_indent
-                    + "[red]"
-                    + line
-                    + "[/red]"
-                )
-        if show_lineno:
-            ret = " " * error_lineno_len + "[dim]│[/dim]" + ret
-        return ret
-
-    @staticmethod
-    def __get_indent(line: str) -> int:
-        if len(line) == 0:
-            return int(1e9)  # very large number
-        return len(line) - len(line.lstrip())
+        self.lineno_begin = lineno_begin
+        self.col_indent = col_indent
 
     def __repr__(self) -> str:
         return (
-            f'File "{self.file or "stdin"}", line {self.lineno}, col {self.col_offset}'
+            f'File "{self.file or "stdin"}", '
+            f"line {self.lineno + self.lineno_begin},"
+            f" col {self.col_offset + self.col_indent}"
         )

--- a/test/interp/test_func.py
+++ b/test/interp/test_func.py
@@ -1,7 +1,6 @@
 import pytest
 
 from kirin.prelude import basic_no_opt
-from kirin.interp.exceptions import IntepreterExit
 
 
 def test_basic():
@@ -61,7 +60,7 @@ def test_assert():
     assert multi(0) == 1
     assert multi(1) is None
 
-    with pytest.raises(IntepreterExit):
+    with pytest.raises(AssertionError):
         multi(2)
 
 

--- a/test/interp/test_select.py
+++ b/test/interp/test_select.py
@@ -42,5 +42,5 @@ def main(x):
 
 def test_interp():
     interp_ = DummyInterpreter(basic)
-    with pytest.raises(interp.IntepreterExit):
+    with pytest.raises(interp.InterpreterError):
         interp_.run(main, (EmptyLattice(),))

--- a/test/lowering/test_with.py
+++ b/test/lowering/test_with.py
@@ -21,7 +21,7 @@ def with_example(x):
 
 
 def test_with_lowering():
-    lower = lowering.Python(python_no_opt.union([cf, func, dialect]), stacktrace=True)
+    lower = lowering.Python(python_no_opt.union([cf, func, dialect]))
     code = lower.python_function(with_example)
     code.print()
     assert isinstance(code, func.Function)

--- a/test/program/py/test_basic.py
+++ b/test/program/py/test_basic.py
@@ -4,7 +4,6 @@ import pytest
 # composite modules
 from aha import gaga, hoho
 
-from kirin.interp import IntepreterExit
 from kirin.prelude import basic_no_opt
 
 
@@ -138,7 +137,7 @@ def test_add(x):
     if x == 1:
         assert add(x) == (x + 1) + (x + 1) + (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: add(x))
+        pytest.raises(AssertionError, lambda: add(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -146,7 +145,7 @@ def test_sub(x):
     if x == 1:
         assert sub(x) == (x + 1) - (x + 1) - (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: sub(x))
+        pytest.raises(AssertionError, lambda: sub(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -154,7 +153,7 @@ def test_mul(x):
     if x == 1:
         assert mul(x) == (x + 1) * (x + 1) * (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: mul(x))
+        pytest.raises(AssertionError, lambda: mul(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -162,7 +161,7 @@ def test_div(x):
     if x == 1:
         assert div(x) == (x + 1) / (x + 1) / (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: div(x))
+        pytest.raises(AssertionError, lambda: div(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -170,7 +169,7 @@ def test_floordiv(x):
     if x == 1:
         assert floordiv(x) == (x + 1) // (x + 1) // (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: floordiv(x))
+        pytest.raises(AssertionError, lambda: floordiv(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -178,7 +177,7 @@ def test_mod(x):
     if x == 1:
         assert mod(x) == (x + 1) % (x + 1) % (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: mod(x))
+        pytest.raises(AssertionError, lambda: mod(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -186,7 +185,7 @@ def test_pow(x):
     if x == 1:
         assert pow(x) == (x + 1) ** (x + 1) ** (x + 1)
     else:
-        pytest.raises(IntepreterExit, lambda: pow(x))
+        pytest.raises(AssertionError, lambda: pow(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -194,7 +193,7 @@ def test_eq(x):
     if x == 1:
         assert eq(x) == ((x + 1) == (x + 1) == (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: eq(x))
+        pytest.raises(AssertionError, lambda: eq(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -202,7 +201,7 @@ def test_ne(x):
     if x == 1:
         assert ne(x) == ((x + 1) != (x + 1) != (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: ne(x))
+        pytest.raises(AssertionError, lambda: ne(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -210,7 +209,7 @@ def test_lt(x):
     if x == 1:
         assert lt(x) == ((x + 1) < (x + 1) < (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: lt(x))
+        pytest.raises(AssertionError, lambda: lt(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -218,7 +217,7 @@ def test_le(x):
     if x == 1:
         assert le(x) == ((x + 1) <= (x + 1) <= (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: le(x))
+        pytest.raises(AssertionError, lambda: le(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -226,7 +225,7 @@ def test_gt(x):
     if x == 1:
         assert gt(x) == ((x + 1) > (x + 1) > (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: gt(x))
+        pytest.raises(AssertionError, lambda: gt(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -234,7 +233,7 @@ def test_ge(x):
     if x == 1:
         assert ge(x) == ((x + 1) >= (x + 1) >= (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: ge(x))
+        pytest.raises(AssertionError, lambda: ge(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -242,7 +241,7 @@ def test_and(x):
     if x == 1:
         assert and_(x) == ((x + 1) and (x + 1) and (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: and_(x))
+        pytest.raises(AssertionError, lambda: and_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -250,7 +249,7 @@ def test_or(x):
     if x == 1:
         assert or_(x) == ((x + 1) or (x + 1) or (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: or_(x))
+        pytest.raises(AssertionError, lambda: or_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -258,7 +257,7 @@ def test_and_or(x):
     if x == 1:
         assert and_or(x) == ((x + 1) and (x + 1) or (x + 1))
     else:
-        pytest.raises(IntepreterExit, lambda: and_or(x))
+        pytest.raises(AssertionError, lambda: and_or(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
@@ -266,7 +265,7 @@ def test_not(x):
     if x == 1:
         assert not_(x) == (not ((x + 1) == (x + 1) == (x + 1)))
     else:
-        pytest.raises(IntepreterExit, lambda: not_(x))
+        pytest.raises(AssertionError, lambda: not_(x))
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])


### PR DESCRIPTION
this PR should be considered non-breaking and let's try to backport it to 0.16 and 0.17 because it recovers the original error behaviour when an error was raised inside the validation or interpreter.