### PR TITLE
rename get_attr_or_prop -> get_attribute

### DIFF
--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -656,7 +656,9 @@ class Statement(IRNode["Block"]):
                     delim=", ",
                 )
 
-    def get_attr_or_prop(self, key: str) -> Attribute | None:
+    def get_attribute(
+        self, key: str, default: Attribute | None = None
+    ) -> Attribute | None:
         """Get the attribute or property of the Statement.
 
         Args:
@@ -665,7 +667,7 @@ class Statement(IRNode["Block"]):
         Returns:
             Attribute | None: The attribute or property of the Statement.
         """
-        return self.attributes.get(key)
+        return self.attributes.get(key, default)
 
     @classmethod
     def has_trait(cls, trait_type: type[Trait["Statement"]]) -> bool:

--- a/src/kirin/ir/traits/symbol.py
+++ b/src/kirin/ir/traits/symbol.py
@@ -19,7 +19,7 @@ class SymbolOpInterface(StmtTrait):
     """
 
     def get_sym_name(self, stmt: Statement) -> PyAttr[str]:
-        sym_name: PyAttr[str] | None = stmt.get_attr_or_prop("sym_name")  # type: ignore
+        sym_name: PyAttr[str] | None = stmt.get_attribute("sym_name")  # type: ignore
         # NOTE: unlike MLIR or xDSL we do not allow empty symbol names
         if sym_name is None:
             raise ValueError(f"Statement {stmt.name} does not have a symbol name")


### PR DESCRIPTION
we removed the concept of inline compile-time data in the IR because we are working in a language with GC (thus no need to distinguish what is stored in the areana). Renaming the API to reflect this.