### PR TITLE
Iter stmt should be non-pure

### DIFF
--- a/src/kirin/dialects/py/iterable.py
+++ b/src/kirin/dialects/py/iterable.py
@@ -26,7 +26,7 @@ PyRangeIterType = types.PyClass(type(iter(range(0))))
 class Iter(ir.Statement):
     """This is equivalent to `iter(value)` in Python."""
 
-    traits = frozenset({ir.Pure()})
+    traits = frozenset({})
     value: ir.SSAValue = info.argument(types.Any)
     iter: ir.ResultValue = info.result(types.Any)
 

--- a/test/dialects/py/test_iter.py
+++ b/test/dialects/py/test_iter.py
@@ -1,0 +1,20 @@
+import kirin.prelude
+
+
+def iter_non_pure():
+    @kirin.prelude.basic
+    def loop(a: str):
+        out = []
+        for i in range(4):
+            # for i in [1,1,2,3]:  # Same result with this line instead
+            out = out + [a]
+        return out
+
+    x = loop("a")
+    assert x == ["a", "a", "a", "a"]
+
+    x = loop("b")
+    assert x == ["b", "b", "b", "b"]
+
+    x = loop("c")
+    assert x == ["c", "c", "c", "c"]


### PR DESCRIPTION
This PR address #389.

Stmt `Iter` to get iterator should not be pure otherwise constfold will cached the iterator itself which is not reusable.  