### PR TITLE
handle multiple result propogation

### DIFF
--- a/src/kirin/analysis/const/prop.py
+++ b/src/kirin/analysis/const/prop.py
@@ -95,8 +95,10 @@ class Propagate(ForwardExtra[Frame, Result]):
                 if types.is_tuple_of(values, Value):
                     return self.try_eval_const_pure(frame, stmt, values)
 
-            if stmt.has_trait(ir.Pure):
-                return (Unknown(),)  # no implementation but pure
+            # If a statement is pure but a method was not found in the registry, 
+            # it should return the number of Unknowns equal to each result
+            if stmt.has_trait(ir.Pure): 
+                return tuple([Unknown() for result in stmt.results])  # no implementation but pure
             # not pure, and no implementation, let's say it's not pure
             frame.frame_is_not_pure = True
             return (Unknown(),)


### PR DESCRIPTION
This fix removes the need for the custom constprop method tables currently found (here) [https://github.com/QuEraComputing/bloqade-circuit/blob/65acb7679d22847b81a9d934f6848aa82606545c/src/bloqade/squin/wire.py#L114]

Credit to @weinbe58 for pointing out that code shouldn't be necessary. 

Without those custom constprop tables the site analysis in bloqade-circuit fails because statements like `Apply` and `Broadcast` in the squin wire dialect have multiple return results and the default behavior in kirin is something like:

```
if no method is registered for this statement,
AND if it is pure, 
THEN just return a SINGLE (Unknown(),)
```
which leads to missing entries in the `frame.entries` post-analysis.

I can't think of a case where this would cause any undesirable behavior for constprop in the generic case which is why I felt comfortable proposing the fix here.