### PR TITLE
fix type hint error for method

### DIFF
--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -547,5 +547,8 @@ def hint2type(hint) -> TypeAttribute:
     args = typing.get_args(hint)
     params = []
     for arg in args:
-        params.append(hint2type(arg))
+        if isinstance(arg, typing.Sequence):
+            params.append([hint2type(elem) for elem in arg])
+        else:
+            params.append(hint2type(arg))
     return Generic(body, *params)

--- a/src/kirin/lowering/python/glob.py
+++ b/src/kirin/lowering/python/glob.py
@@ -100,3 +100,6 @@ class GlobalExprEval(ast.NodeVisitor):
 
     def visit_Tuple(self, node: ast.Tuple) -> Any:
         return tuple(self.visit(elt) for elt in node.elts)
+
+    def visit_List(self, node: ast.List) -> Any:
+        return [self.visit(elt) for elt in node.elts]

--- a/test/lowering/test_method_hint.py
+++ b/test/lowering/test_method_hint.py
@@ -1,0 +1,16 @@
+from kirin import ir, types
+from kirin.prelude import basic
+
+
+def test_method_type_hint():
+    @basic
+    def main() -> ir.Method[[int, int], float]:
+
+        def test(x: int, y: int) -> float:
+            return x * y * 3.0
+
+        return test
+
+    assert main.return_type == types.Generic(
+        ir.Method, [types.Int, types.Int], types.Float
+    )


### PR DESCRIPTION
This PR address #106

The issue is that for type hint of Callable such as Method, one of the ast argument is a list. This means that the hint2type need to consider the edge case when visiting the hint. 

