### PR TITLE
feat: add result value to function

### DIFF
--- a/src/kirin/dialects/func/stmts.py
+++ b/src/kirin/dialects/func/stmts.py
@@ -51,6 +51,8 @@ class Function(ir.Statement):
     """The signature of the function at declaration."""
     body: ir.Region = info.region(multi=True)
     """The body of the function."""
+    result: ir.ResultValue = info.result(MethodType)
+    """The result of the function."""
 
     def print_impl(self, printer: Printer) -> None:
         with printer.rich(style="keyword"):


### PR DESCRIPTION
function can have a return value even when we are talking about Python functions, e.g when one write

```python
def foo(x: int):
    pass
```

we can interpret this as assigning a value of `Method` to the variable `foo`. This makes downstream analysis and codegen easier because now we have a place to store what the function represents