### PR TITLE
fixing hash(-1) == hash(-2) (attempt 2)

### DIFF
--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -36,8 +36,9 @@ class PyAttr(Data[T]):
 
     def __hash__(self):
         # Fix hash(-1) == hash(-2) collision
+        # assume maximum is 8 bytes == 64 bits
         if isinstance(self.data, int):
-            return self.data
+            return hash(self.data.to_bytes(signed=True, length=8))
         return hash(self.data) + hash(self.type)
 
     def print_impl(self, printer: Printer) -> None:

--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -39,6 +39,8 @@ class PyAttr(Data[T]):
         # assume maximum is 8 bytes == 64 bits
         if isinstance(self.data, int):
             return hash(self.data.to_bytes(signed=True, length=8))
+        elif isinstance(self.data, float):
+            return hash(self.data.hex())
         return hash(self.data) + hash(self.type)
 
     def print_impl(self, printer: Printer) -> None:

--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -38,7 +38,7 @@ class PyAttr(Data[T]):
         # Fix hash(-1) == hash(-2) collision
         # assume maximum is 8 bytes == 64 bits
         if isinstance(self.data, int):
-            return hash(self.data.to_bytes(signed=True, length=8))
+            return hash(self.data.to_bytes(signed=True, byteorder="big", length=8))
         elif isinstance(self.data, float):
             return hash(self.data.hex())
         return hash(self.data) + hash(self.type)

--- a/test/ir/test_hash.py
+++ b/test/ir/test_hash.py
@@ -1,0 +1,11 @@
+from kirin import ir
+
+def test_hash():
+    # Test hash collision for PyAttr with different values
+    # This is a regression test for issue #1234
+    # where hash(-1) == hash(-2) for PyAttr
+    # This is fixed by using the value as bytes
+    a = ir.PyAttr(-1)
+    b = ir.PyAttr(-2)
+    assert hash(a) != hash(b)
+    assert hash(a.data) == hash(b.data)

--- a/test/ir/test_hash.py
+++ b/test/ir/test_hash.py
@@ -9,3 +9,8 @@ def test_hash():
     b = ir.PyAttr(-2)
     assert hash(a) != hash(b)
     assert hash(a.data) == hash(b.data)
+
+    a = ir.PyAttr(-1.0)
+    b = ir.PyAttr(-2.0)
+    assert hash(a) != hash(b)
+    assert hash(a.data) == hash(b.data)

--- a/test/ir/test_hash.py
+++ b/test/ir/test_hash.py
@@ -1,5 +1,6 @@
 from kirin import ir
 
+
 def test_hash():
     # Test hash collision for PyAttr with different values
     # This is a regression test for issue #1234


### PR DESCRIPTION
ok so just return the integer does not work because Python will hash that result with a seed implicitly. Here we convert the integer to a byte and float to a hex repr. This is not the most ideal fix due to the fact that Python is using fixpoint/infinite precision numbers. But this should be non-breaking. We will do another fix by switching all `int` to `np.int64` and `float` to `np.float64` and define the hash as their bytes later.