### PR TITLE
Fix bug that ignored defs in if when missing from else

### DIFF
--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -10,6 +10,22 @@ from ._dialect import dialect
 @dialect.register
 class Lowering(lowering.FromPythonAST):
 
+    @staticmethod
+    def _frame_or_any_parent_has_def(frame, name) -> ir.SSAValue | None:
+        # NOTE: this recursively checks all parents of the current frame for the
+        # def. Required for nested if statements that e.g. assign to variables
+        # defined in outer scope
+        if frame is None:
+            return None
+
+        if name in frame.defs:
+            value = frame.get(name)
+            if value is None:
+                raise lowering.BuildError(f"expected value for {name}")
+            return value
+
+        return Lowering._frame_or_any_parent_has_def(frame.parent, name)
+
     def lower_If(self, state: lowering.State, node: ast.If) -> lowering.Result:
         cond = state.lower(node.test).expect_one()
         frame = state.current_frame
@@ -34,20 +50,9 @@ class Lowering(lowering.FromPythonAST):
                 yield_names.append(name)
                 body_yields.append(body_frame[name])
                 else_yields.append(else_frame[name])
-            elif name in frame.defs:
+            elif (value := self._frame_or_any_parent_has_def(frame, name)) is not None:
                 yield_names.append(name)
                 body_yields.append(body_frame[name])
-                value = frame.get(name)
-                if value is None:
-                    raise lowering.BuildError(f"expected value for {name}")
-                else_yields.append(value)
-            elif frame.parent is not None and name in frame.parent.defs:
-                # NOTE: check outer frame definitions too
-                yield_names.append(name)
-                body_yields.append(body_frame[name])
-                value = frame.parent.get(name)
-                if value is None:
-                    raise lowering.BuildError(f"expected value for {name}")
                 else_yields.append(value)
 
         if not (

--- a/test/dialects/scf/test_ifelse.py
+++ b/test/dialects/scf/test_ifelse.py
@@ -65,6 +65,9 @@ def test_if_else_defs():
     main2 = main.similar(kernel)
     Fold(main2.dialects)(main2)
 
+    assert main(0) == 1 == main2(0)
+    assert main(10) == 0 == main2(4)
+
     main2.print()
 
     @kernel
@@ -84,3 +87,26 @@ def test_if_else_defs():
     Fold(main_elif2.dialects)(main_elif2)
 
     main_elif2.print()
+
+    assert main_elif(0) == 3 == main_elif2(0)
+    assert main_elif(-1) == 4 == main_elif2(-1)
+    assert main_elif(5) == 0 == main_elif2(7)
+
+    @kernel
+    def main_nested_if(n: int):
+        x = 0
+
+        if n > 0:
+            if n > 1:
+                if n == 3:
+                    x = 4
+
+        return x
+
+    main_nested_if.print()
+
+    main_nested_if2 = main_nested_if.similar(kernel)
+    Fold(main_nested_if2.dialects)(main_nested_if2)
+
+    assert main_nested_if(3) == 4 == main_nested_if2(3)
+    assert main_nested_if(10) == 0 == main_nested_if2(8)


### PR DESCRIPTION
@Roger-luo this fixes the bug in #416 when there's a definition in the `if` path, but not in the `else` path.

However, the issue with the `elif` persists since the definition from the nested if isn't propagated upwards properly.

In code:

This fails on main, but works on this branch

```python
@kernel
def main(n: int):
    x = 0

    if x == n:
        x = 1
    else:
        y = 2  # noqa: F841

    return x

main.print()
```

This fails both on main and this branch:
```python
@kernel
def main_elif(n: int):
    x = 0

    if x == n:
        x = 3
    elif x == n + 1:
        x = 4

    return x

main_elif.print()
```

(or, equivalently)
```python
@kernel
def main_elif(n: int):
    x = 0

    if x == n:
        x = 3
    else:
        if x == n + 1:
            x = 4

    return x

```

We somehow need to lower the bodies first in order to obtain the nested definitions in them, but I'm not sure how exactly.