### PR TITLE
Fix type inference of loop variable on v0.17

### DIFF
--- a/src/kirin/dialects/scf/scf2cf.py
+++ b/src/kirin/dialects/scf/scf2cf.py
@@ -175,11 +175,7 @@ class ScfToCfRule(RewriteRule):
         return RewriteResult(has_done_something=has_done_something)
 
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
-        if (
-            isinstance(node, (For, IfElse))
-            or not node.has_trait(ir.HasCFG)
-            and not node.has_trait(ir.SSACFG)
-        ):
+        if isinstance(node, (For, IfElse)):
             # do not do rewrite in scf regions
             return RewriteResult()
 

--- a/src/kirin/dialects/scf/typeinfer.py
+++ b/src/kirin/dialects/scf/typeinfer.py
@@ -45,10 +45,9 @@ class TypeInfer(absint.Methods):
             frame.worklist.append(interp.Successor(body_block, item, *loop_vars))
             return  # if terminate is Return, there is no result
 
-        with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
-            loop_vars_ = interp_.run_ssacfg_region(
-                body_frame, stmt.body, (iterable,) + loop_vars
-            )
+        with interp_.new_frame(stmt) as body_frame:
+            body_frame.entries.update(frame.entries)
+            loop_vars_ = interp_.run_ssacfg_region(body_frame, stmt.body, args=())
 
         frame.entries.update(body_frame.entries)
         if isinstance(loop_vars_, interp.ReturnValue):

--- a/test/dialects/scf/test_scf2cf.py
+++ b/test/dialects/scf/test_scf2cf.py
@@ -63,7 +63,6 @@ def test_scf2cf_if_1():
 
     expected_code = func.Function(
         sym_name="test",
-        slots=("b",),
         signature=func.Signature(
             output=types.Bool,
             inputs=(types.Bool,),
@@ -74,6 +73,10 @@ def test_scf2cf_if_1():
     expected_test = ir.Method(
         dialects=basic,
         code=expected_code,
+        mod=None,
+        py_func=None,
+        sym_name="expected_test",
+        arg_names=[],
     )
 
     if basic.run_pass is not None:
@@ -176,7 +179,6 @@ def test_scf2cf_for_1():
 
     expected_code = func.Function(
         sym_name="test",
-        slots=(),
         signature=func.Signature(
             output=types.Literal(10),
             inputs=(),
@@ -187,6 +189,10 @@ def test_scf2cf_for_1():
     expected_test = ir.Method(
         dialects=basic,
         code=expected_code,
+        mod=None,
+        py_func=None,
+        sym_name="expected_test",
+        arg_names=[],
     )
 
     test.print()

--- a/test/dialects/scf/test_typeinfer.py
+++ b/test/dialects/scf/test_typeinfer.py
@@ -1,6 +1,7 @@
 from kirin import types
 from kirin.prelude import structural_no_opt
 from kirin.analysis import TypeInference
+from kirin.dialects import ilist
 
 type_infer = TypeInference(structural_no_opt)
 
@@ -27,3 +28,34 @@ def test_simple_ifelse():
 
     frame, ret = type_infer.run_analysis(simple_ifelse)
     assert ret.is_subseteq(types.Bool | types.Int | types.NoneType)
+
+
+def test_getitem_inside_loop():
+    @structural_no_opt
+    def getitem_loop():
+        ls = [1, 2, 3]
+        for i in range(2):
+            ls[i + 1]
+
+    frame, ret = type_infer.run_analysis(getitem_loop)
+
+    getitem_loop.print(analysis=frame.entries)
+
+    # NOTE: go through values, but skip method and return
+    for value in list(frame.entries.values())[1:-1]:
+        # everything except the method & return should either be int or a list[int]
+        print(value)
+        print(value.is_subseteq(types.Int | ilist.IListType[types.Int, types.Any]))
+
+    assert ret.is_subseteq(types.NoneType)
+
+    @structural_no_opt
+    def getitem_return_from_loop():
+        ls = [1, 2, 3]
+        for i in range(2):
+            return ls[i + 1]
+
+        return 1.0
+
+    frame, ret = type_infer.run_analysis(getitem_return_from_loop)
+    assert ret.is_subseteq(types.Int | types.Float)


### PR DESCRIPTION
**NOTE**: this is a **backport only fix**, i.e. it's a patch for v0.17 only (the issue is no longer present on v0.18+).

This is a small fix that causes a lot of trouble downstream. It was easier to fix here than adding workarounds in bloqade-circuit. I hope that's okay.

As far as I can tell, the only thing we "lose" are a couple of tests (which I added here) and it makes future fixes that touch the same code more difficult to backport (but it's only three lines I touched).