### PR TITLE
Fix trim UnusedYield

### DIFF
--- a/src/kirin/dialects/scf/trim.py
+++ b/src/kirin/dialects/scf/trim.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from kirin import ir
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 
@@ -21,6 +23,32 @@ class UnusedYield(RewriteRule):
                 any_unused = True
         return any_unused, set(uses), results
 
+    def get_equal_args(self, node: For) -> Dict[int, List[int]]:
+        """Other iter_args indices that are equal to each index."""
+        equal_args: Dict[int, List[int]] = {}
+        original_iter_args = node.body.blocks[0].args[1:]
+        original_yields = [
+            block.last_stmt.args
+            for region in node.regions
+            for block in region.blocks
+            if isinstance(block.last_stmt, Yield)
+        ]
+
+        for idx_1 in range(len(node.results)):
+            equal_args[idx_1] = []
+            for idx_2 in range(len(node.results)):
+                are_equal = True
+                if original_iter_args[idx_1].name != original_iter_args[idx_2].name:
+                    are_equal = False
+                if node.initializers[idx_1] != node.initializers[idx_2]:
+                    are_equal = False
+                for values in original_yields:
+                    if values[idx_1] != values[idx_2]:
+                        are_equal = False
+                if are_equal and idx_1 != idx_2:
+                    equal_args[idx_1].append(idx_2)
+        return equal_args
+
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
         if not isinstance(node, (For, IfElse)):
             return RewriteResult()
@@ -29,7 +57,19 @@ class UnusedYield(RewriteRule):
         if not any_unused:
             return RewriteResult()
 
+        all_idx = list(range(len(node.results)))
+        idx_drop = [idx for idx in all_idx if idx not in uses]
+
+        equal_args: Dict[int, List[int]] = {}
+        if isinstance(node, For):
+            equal_args = self.get_equal_args(node)
+            equal_args = {
+                idx: [other_idx for other_idx in others if other_idx not in idx_drop]
+                for idx, others in equal_args.items()
+            }
+
         node._results = results
+
         for region in node.regions:
             for block in region.blocks:
                 if not isinstance(block.last_stmt, Yield):
@@ -38,9 +78,23 @@ class UnusedYield(RewriteRule):
                 block.last_stmt.args = [block.last_stmt.args[idx] for idx in uses]
 
         if isinstance(node, For):
-            for idx, block_arg in enumerate(node.body.blocks[0].args[1:]):
-                if idx not in uses:
-                    block_arg.replace_by(node.initializers[idx])
-                    block_arg.delete()
-            node.initializers = tuple(node.initializers[idx] for idx in uses)
+            idx_arg_drop = set()
+            iter_args = node.body.blocks[0].args[1:]
+            for idx in idx_drop:
+                if len(iter_args[idx].uses) == 0:
+                    idx_arg_drop.add(idx)
+                elif len(equal_args[idx]) == 0:
+                    idx_arg_drop.add(idx)
+                else:
+                    for equal_idx in equal_args[idx]:
+                        if len(iter_args[equal_idx].uses) == 0:
+                            idx_arg_drop.add(equal_idx)
+                            break
+            idx_arg_keep = sorted(set(all_idx) - idx_arg_drop)
+
+            for idx in sorted(idx_arg_drop):
+                block_arg = iter_args[idx]
+                block_arg.replace_by(node.initializers[idx])
+                block_arg.delete()
+            node.initializers = tuple(node.initializers[idx] for idx in idx_arg_keep)
         return RewriteResult(has_done_something=True)


### PR DESCRIPTION
Fix the problem with unused yield removing the wrong arguments.
Fixes Issue #452.

The reason root cause is the following.
For example, consider the example in the Issue.
```python
@structural
def main(n: int):
    x = 0
    for i in range(n):
        x += i
    return x
```
which becomes the following IR
```llvm
func.func @main(n : !py.int) -> !Any {
  ^0(%main_self, %n):
  │         %x = py.constant.constant 0 : !py.int
  │         %0 = py.constant.constant 0 : !py.int
  │         %1 = py.constant.constant 1 : !py.int
  │         %2 = py.ilist.range(start=%0, stop=%n : !py.int, step=%1) : !py.IList[!py.int, !Any]
  │ %x_1, %x_2 = scf.for %i in %2 -> ~T, ~T
  │              │ iter_args(%x_3 : !py.int = %x, %x_4 : ~T = %x) {
  │              │ %x_5 = py.binop.add(%x_3 : !py.int, %i) : ~T
  │              │        scf.yield %x_5, %x_5
  │              } -> purity=False
  │              func.return %x_2
} // func.func main
```

In this case, each iteration of the for loop yields the the same value twice.
The old behaviour of `scf.trim.UnusedYield` rewrites the for loop to this:
```llvm
func.func @main(n : !py.int) -> !Any {
  ^0(%main_self, %n):
  │   %x = py.constant.constant 0 : !py.int
  │   %0 = py.constant.constant 0 : !py.int
  │   %1 = py.constant.constant 1 : !py.int
  │   %2 = py.ilist.range(start=%0, stop=%n : !py.int, step=%1) : !py.IList[!py.int, !Any]
  │ %x_1 = scf.for %i in %2 -> ~T
  │        │ iter_args(%x_2 : ~T = %x) {
  │        │ %x_3 = py.binop.add(%x, %i) : ~T
  │        │        scf.yield %x_3
  │        } -> purity=False
  │        func.return %x_1
} // func.func main
```

It seems to be deleting the first argument it sees everywhere, without regard for whether or not it is used later on when there are other equal values which should be deleted.
This is incorrect, since the `iter_arg` value `%x_2` is clearly not used in the arguments of the `add` statement for `%x_3` which is what is returned. Instead `%x` is used, which would be equivalent to returning `0 + n-1`, not using anything from the previous iterations.

Instead this should be the correct behaviour:

```llvm
func.func @main(n : !py.int) -> !Any {
  ^0(%main_self, %n):
  │   %x = py.constant.constant 0 : !py.int
  │   %0 = py.constant.constant 0 : !py.int
  │   %1 = py.constant.constant 1 : !py.int
  │   %2 = py.ilist.range(start=%0, stop=%n : !py.int, step=%1) : !py.IList[!py.int, !Any]
  │ %x_1 = scf.for %i in %2 -> ~T
  │        │ iter_args(%x_2 : !py.int = %x) {
  │        │ %x_3 = py.binop.add(%x_2 : !py.int, %i) : ~T
  │        │        scf.yield %x_3
  │        } -> purity=False
  │        func.return %x_1
} // func.func main
```

In the above the `%x_2` argument is actually used in the `add` statement. 

This PR corrects this incorrect behaviour to correctly delete the right argument when they are both the same.