### PR TITLE
fix scf trim + lowering

### DIFF
--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -128,7 +128,7 @@ class Lowering(lowering.FromPythonAST):
             initializers.append(value)
         stmt = For(iter_, body_frame.curr_region, *initializers)
 
-        for name, result in zip(yields, stmt.results):
+        for name, result in zip(reversed(yields), reversed(stmt.results)):
             state.current_frame.defs[name] = result
             result.name = name
         state.current_frame.push(stmt)


### PR DESCRIPTION
There appears to be a bug in trim because of a bug in lowering a for loop.

The for loop was assigning variable names outside of the loop body to the latest return values of the for loop statement but the semantics assumes that the earliest names are to be assigned to the values outside of the loop. To fix this issue when updating the lowering state I iterate over the yielded names and ssa values in reverse. 

Then there seemed to be some not clear logic in the current implementation of how the for loop statement was being updated during the trim rewrite. Namely the block arguments were being deleted while looping over the block arguments container which messes up the positions of future block arguments. Instead I first do the ssa value replacements then delete the block arguments in two separate steps. 