### PR TITLE
Adding `ScfUnroll` Pass

### DIFF
--- a/src/kirin/dialects/scf/unroll.py
+++ b/src/kirin/dialects/scf/unroll.py
@@ -88,4 +88,4 @@ class ForLoop(RewriteRule):
         for result, output in zip(node.results, loop_vars):
             result.replace_by(output)
         node.delete()
-        return RewriteResult(has_done_something=True, terminated=True)
+        return RewriteResult(has_done_something=True)

--- a/src/kirin/passes/aggressive/__init__.py
+++ b/src/kirin/passes/aggressive/__init__.py
@@ -1,1 +1,2 @@
 from .fold import Fold as Fold
+from .unroll import UnrollScf as UnrollScf

--- a/src/kirin/passes/aggressive/scf_unroll.py
+++ b/src/kirin/passes/aggressive/scf_unroll.py
@@ -1,0 +1,32 @@
+from dataclasses import field, dataclass
+
+from kirin import ir, rewrite
+from kirin.passes import Pass
+from kirin.rewrite import abc
+from kirin.passes.typeinfer import TypeInfer
+from kirin.dialects.scf.unroll import ForLoop, PickIfElse
+
+from ..fold import Fold
+
+
+@dataclass
+class UnrollScf(Pass):
+    """This pass can be used to unroll scf.For loops and inline/expand scf.IfElse when
+    the input are known at compile time.
+
+    """
+
+    typeinfer: TypeInfer = field(init=False)
+    fold: Fold = field(init=False)
+
+    def __post_init__(self):
+        self.typeinfer = TypeInfer(self.dialects, no_raise=self.no_raise)
+        self.fold = Fold(self.dialects, no_raise=self.no_raise)
+
+    def unsafe_run(self, mt: ir.Method):
+        result = abc.RewriteResult()
+        result = rewrite.Walk(PickIfElse()).rewrite(mt.code).join(result)
+        result = rewrite.Walk(ForLoop()).rewrite(mt.code).join(result)
+        result = self.typeinfer(mt).join(result)
+        result = self.fold(mt).join(result)
+        return result

--- a/src/kirin/passes/aggressive/unroll.py
+++ b/src/kirin/passes/aggressive/unroll.py
@@ -1,12 +1,10 @@
 from dataclasses import field, dataclass
 
-from kirin import ir, rewrite
-from kirin.passes import Pass
-from kirin.rewrite import abc
-from kirin.passes.typeinfer import TypeInfer
+from kirin.ir import Method
+from kirin.passes import Fold, Pass, TypeInfer
+from kirin.rewrite import Walk
+from kirin.rewrite.abc import RewriteResult
 from kirin.dialects.scf.unroll import ForLoop, PickIfElse
-
-from ..fold import Fold
 
 
 @dataclass
@@ -28,10 +26,10 @@ class UnrollScf(Pass):
         self.typeinfer = TypeInfer(self.dialects, no_raise=self.no_raise)
         self.fold = Fold(self.dialects, no_raise=self.no_raise)
 
-    def unsafe_run(self, mt: ir.Method):
-        result = abc.RewriteResult()
-        result = rewrite.Walk(PickIfElse()).rewrite(mt.code).join(result)
-        result = rewrite.Walk(ForLoop()).rewrite(mt.code).join(result)
+    def unsafe_run(self, mt: Method):
+        result = RewriteResult()
+        result = Walk(PickIfElse()).rewrite(mt.code).join(result)
+        result = Walk(ForLoop()).rewrite(mt.code).join(result)
         result = self.typeinfer(mt).join(result)
         result = self.fold(mt).join(result)
         return result

--- a/src/kirin/passes/aggressive/unroll.py
+++ b/src/kirin/passes/aggressive/unroll.py
@@ -14,6 +14,11 @@ class UnrollScf(Pass):
     """This pass can be used to unroll scf.For loops and inline/expand scf.IfElse when
     the input are known at compile time.
 
+    usage:
+        UnrollScf(dialects).fixpoint(method)
+
+    Note: This pass should be used in a fixpoint manner, to unroll nested scf nodes.
+
     """
 
     typeinfer: TypeInfer = field(init=False)

--- a/test/passes/test_unroll_scf.py
+++ b/test/passes/test_unroll_scf.py
@@ -1,6 +1,6 @@
 from kirin.prelude import structural
 from kirin.dialects import py, func
-from kirin.passes.aggressive.scf_unroll import UnrollScf
+from kirin.passes.aggressive import UnrollScf
 
 
 def test_unroll_scf():

--- a/test/passes/test_unroll_scf.py
+++ b/test/passes/test_unroll_scf.py
@@ -4,26 +4,28 @@ from kirin.passes.aggressive import UnrollScf
 
 
 def test_unroll_scf():
-
     @structural
-    def main(r: list[int]):
-        for i in range(4):
-            tmp = r[-1]
-            if i < 2:
-                tmp += i * 2
-            else:
-                for j in range(4):
-                    if i > j:
-                        tmp += i + j
-                    else:
-                        tmp += i - j
+    def main(r: list[int], cond: bool):
+        if cond:
+            for i in range(4):
+                tmp = r[-1]
+                if i < 2:
+                    tmp += i * 2
+                else:
+                    for j in range(4):
+                        if i > j:
+                            tmp += i + j
+                        else:
+                            tmp += i - j
 
-            r.append(tmp)
-
+                r.append(tmp)
+        else:
+            for i in range(4):
+                r.append(i)
         return r
 
     UnrollScf(structural).fixpoint(main)
-
+    main.print()
     num_adds = 0
     num_calls = 0
 
@@ -34,4 +36,4 @@ def test_unroll_scf():
             num_calls += 1
 
     assert num_adds == 10
-    assert num_calls == 4
+    assert num_calls == 8

--- a/test/passes/test_unroll_scf.py
+++ b/test/passes/test_unroll_scf.py
@@ -1,0 +1,37 @@
+from kirin.prelude import structural
+from kirin.dialects import py, func
+from kirin.passes.aggressive.scf_unroll import UnrollScf
+
+
+def test_unroll_scf():
+
+    @structural
+    def main(r: list[int]):
+        for i in range(4):
+            tmp = r[-1]
+            if i < 2:
+                tmp += i * 2
+            else:
+                for j in range(4):
+                    if i > j:
+                        tmp += i + j
+                    else:
+                        tmp += i - j
+
+            r.append(tmp)
+
+        return r
+
+    UnrollScf(structural).fixpoint(main)
+
+    num_adds = 0
+    num_calls = 0
+
+    for op in main.callable_region.walk():
+        if isinstance(op, py.Add):
+            num_adds += 1
+        elif isinstance(op, func.Call):
+            num_calls += 1
+
+    assert num_adds == 10
+    assert num_calls == 4

--- a/test/passes/test_unroll_scf.py
+++ b/test/passes/test_unroll_scf.py
@@ -25,7 +25,7 @@ def test_unroll_scf():
         return r
 
     UnrollScf(structural).fixpoint(main)
-    main.print()
+
     num_adds = 0
     num_calls = 0
 


### PR DESCRIPTION
This PR packages the current `scf.unroll` rewrite rules into a pass to be used to try and unroll the scf. 

The usage:

```python
from kirin. passes.aggressive import UnrollScf
UnrollScf(dialects).fixpoint(method)
```

For a single application, this pass unrolls the top-level of scf nodes in the method body. Therefore, to unroll nested SCF you must apply this in a fixpoint way. 

The modification if removing `terminate` in the UnrollFor rewrite rule fixes issue #475 because now this Pass fixpoint should be over the depth of the nesting, not the number of iterations. 