### PR TITLE
Ban early termination inside SCF. 

### DIFF
--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -71,8 +71,8 @@ class Lowering(lowering.FromPythonAST):
                 else_yields.append(value)
 
         if not (
-            (last_stmt := body_frame.curr_block.last_stmt)
-            and last_stmt.has_trait(ir.IsTerminator)
+            body_frame.curr_block.last_stmt
+            and body_frame.curr_block.last_stmt.has_trait(ir.IsTerminator)
         ):
             body_frame.push(Yield(*body_yields))
         else:

--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -71,16 +71,28 @@ class Lowering(lowering.FromPythonAST):
                 else_yields.append(value)
 
         if not (
-            body_frame.curr_block.last_stmt
-            and body_frame.curr_block.last_stmt.has_trait(ir.IsTerminator)
+            (last_stmt := body_frame.curr_block.last_stmt)
+            and last_stmt.has_trait(ir.IsTerminator)
         ):
             body_frame.push(Yield(*body_yields))
+        else:
+            # python only has one kind of terminator statement
+            # in this case we
+            raise lowering.BuildError(
+                "Early returns/terminators in if bodies are not supported with structured control flow"
+            )
 
         if not (
             else_frame.curr_block.last_stmt
             and else_frame.curr_block.last_stmt.has_trait(ir.IsTerminator)
         ):
             else_frame.push(Yield(*else_yields))
+        else:
+            # python only has one kind of terminator statement
+            # in this case we
+            raise lowering.BuildError(
+                "Early returns/terminators in if bodies are not supported with structured control flow"
+            )
 
         stmt = IfElse(
             cond,
@@ -134,6 +146,12 @@ class Lowering(lowering.FromPythonAST):
             elif body_has_no_terminator:
                 # NOTE: no yields, but also no terminator, add empty yield
                 body_frame.push(Yield())
+            else:
+                # python only has one kind of terminator statement
+                # in this case we
+                raise lowering.BuildError(
+                    "Early returns/terminators in for loops are not supported with structured control flow"
+                )
 
         initializers: list[ir.SSAValue] = []
         for name in yields:

--- a/src/kirin/dialects/scf/lowering.py
+++ b/src/kirin/dialects/scf/lowering.py
@@ -76,8 +76,7 @@ class Lowering(lowering.FromPythonAST):
         ):
             body_frame.push(Yield(*body_yields))
         else:
-            # python only has one kind of terminator statement
-            # in this case we
+            # TODO: Remove this error when we support early termination in if bodies
             raise lowering.BuildError(
                 "Early returns/terminators in if bodies are not supported with structured control flow"
             )
@@ -88,8 +87,7 @@ class Lowering(lowering.FromPythonAST):
         ):
             else_frame.push(Yield(*else_yields))
         else:
-            # python only has one kind of terminator statement
-            # in this case we
+            # TODO: Remove this error when we support early termination in if bodies
             raise lowering.BuildError(
                 "Early returns/terminators in if bodies are not supported with structured control flow"
             )
@@ -147,8 +145,7 @@ class Lowering(lowering.FromPythonAST):
                 # NOTE: no yields, but also no terminator, add empty yield
                 body_frame.push(Yield())
             else:
-                # python only has one kind of terminator statement
-                # in this case we
+                # TODO: Remove this error when we support early termination in for loops
                 raise lowering.BuildError(
                     "Early returns/terminators in for loops are not supported with structured control flow"
                 )

--- a/test/analysis/dataflow/typeinfer/test_inter_method.py
+++ b/test/analysis/dataflow/typeinfer/test_inter_method.py
@@ -1,26 +1,26 @@
+from pytest import mark
+
 from kirin import types
 from kirin.prelude import basic
 
 
-@basic
-def foo(x: int):
-    if x > 1:
-        return x + 1
-    else:
-        return x - 1.0
-
-
-@basic(typeinfer=True, no_raise=False)
-def main(x: int):
-    return foo(x)
-
-
-@basic(typeinfer=True, no_raise=False)
-def moo(x):
-    return foo(x)
-
-
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_inter_method_infer():
+    @basic
+    def foo(x: int):
+        if x > 1:
+            return x + 1
+        else:
+            return x - 1.0
+
+    @basic(typeinfer=True, no_raise=False)
+    def main(x: int):
+        return foo(x)
+
+    @basic(typeinfer=True, no_raise=False)
+    def moo(x):
+        return foo(x)
+
     assert main.return_type == (types.Int | types.Float)
     # assert moo.arg_types[0] == types.Int  # type gets narrowed based on callee
     assert moo.return_type == (types.Int | types.Float)
@@ -30,6 +30,7 @@ def test_inter_method_infer():
     assert foo.return_type is types.Any
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_infer_if_return():
     from kirin.prelude import structural
 

--- a/test/analysis/dataflow/typeinfer/test_selfref_closure.py
+++ b/test/analysis/dataflow/typeinfer/test_selfref_closure.py
@@ -1,8 +1,11 @@
+from pytest import mark
+
 from kirin import types
 from kirin.prelude import structural_no_opt
 from kirin.analysis import TypeInference
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_self_ref_closure():
 
     @structural_no_opt

--- a/test/dialects/scf/test_constprop.py
+++ b/test/dialects/scf/test_constprop.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 from kirin.prelude import structural_no_opt
 from kirin.analysis import const
 from kirin.dialects import scf, func
@@ -69,6 +71,7 @@ def test_nested_loop_with_if_else():
     assert frame.frame_is_not_pure is False
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_inside_return():
     @structural_no_opt
     def simple_loop(x: float):

--- a/test/dialects/scf/test_ifelse.py
+++ b/test/dialects/scf/test_ifelse.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 from kirin import ir
 from kirin.passes import Fold
 from kirin.prelude import python_basic
@@ -23,6 +25,7 @@ def kernel(self):
     return run_pass
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_basic_if_else():
     @kernel
     def main(x):
@@ -112,6 +115,7 @@ def test_if_else_defs():
     assert main_nested_if(10) == 0 == main_nested_if2(8)
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_def_only_else():
     @kernel
     def main(n: int):
@@ -127,6 +131,7 @@ def test_def_only_else():
     assert main(0) == 0.0
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_def_only_else_nested():
     @kernel
     def main(n: int):

--- a/test/dialects/scf/test_typeinfer.py
+++ b/test/dialects/scf/test_typeinfer.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 from kirin import types
 from kirin.prelude import structural_no_opt
 from kirin.analysis import TypeInference
@@ -5,6 +7,7 @@ from kirin.analysis import TypeInference
 type_infer = TypeInference(structural_no_opt)
 
 
+@mark.xfail(reason="for with early return not supported in scf lowering")
 def test_inside_return_loop():
     @structural_no_opt
     def simple_loop(x: float):
@@ -16,6 +19,7 @@ def test_inside_return_loop():
     assert ret.is_subseteq(types.Int | types.Float)
 
 
+@mark.xfail(reason="if with early return not supported in scf lowering")
 def test_simple_ifelse():
     @structural_no_opt
     def simple_ifelse(x: int):


### PR DESCRIPTION
Just to be safe, I am adding a ban on all terminators for SCF. 

I also marked tests that failed due to this change as `xfail`.