### PR TITLE
Make Literal compare as == intead of just id

### DIFF
--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -222,6 +222,7 @@ class Literal(TypeAttribute, typing.Generic[LiteralType], metaclass=LiteralMeta)
     name = "Literal"
     data: LiteralType
     type: TypeAttribute
+
     """type of the literal, this is useful when the Python type of
     data does not represent the type in IR, e.g Literal(1, types.Int32)
     """
@@ -231,7 +232,7 @@ class Literal(TypeAttribute, typing.Generic[LiteralType], metaclass=LiteralMeta)
         self.type = datatype or PyClass(type(data))
 
     def is_equal(self, other: TypeAttribute) -> bool:
-        return self is other
+        return self == other
 
     def is_subseteq_TypeVar(self, other: "TypeVar") -> bool:
         return self.is_subseteq(other.bound)

--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -232,7 +232,11 @@ class Literal(TypeAttribute, typing.Generic[LiteralType], metaclass=LiteralMeta)
         self.type = datatype or PyClass(type(data))
 
     def is_equal(self, other: TypeAttribute) -> bool:
-        return self == other
+        return (
+            isinstance(other, Literal)
+            and self.type.is_equal(other.type)
+            and self.data == other.data
+        )
 
     def is_subseteq_TypeVar(self, other: "TypeVar") -> bool:
         return self.is_subseteq(other.bound)


### PR DESCRIPTION
As per discussion, 

we are making this Literal comparison `is_equal` to be == instead of just compare id, since it contain runtime. 
Another issue will be created to refactor this to make it more performant