### PR TITLE
Make compatible with numpy 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.10"
 
 [project.optional-dependencies]
 vmath = [
-    "numpy>=2.2.6",
+    "numpy>1.26.0",
     "scipy>=1.15.3",
 ]
 [build-system]

--- a/src/kirin/dialects/vmath/interp.py
+++ b/src/kirin/dialects/vmath/interp.py
@@ -15,31 +15,37 @@ class MathMethodTable(MethodTable):
     @impl(stmts.acos)
     def acos(self, interp, frame: Frame, stmt: stmts.acos):
         values = frame.get_values(stmt.args)
-        return (ilist.IList(np.acos(np.asarray(values[0])).tolist(), elem=types.Float),)
+        return (
+            ilist.IList(np.arccos(np.asarray(values[0])).tolist(), elem=types.Float),
+        )
 
     @impl(stmts.asin)
     def asin(self, interp, frame: Frame, stmt: stmts.asin):
         values = frame.get_values(stmt.args)
-        return (ilist.IList(np.asin(np.asarray(values[0])).tolist(), elem=types.Float),)
+        return (
+            ilist.IList(np.arcsin(np.asarray(values[0])).tolist(), elem=types.Float),
+        )
 
     @impl(stmts.asinh)
     def asinh(self, interp, frame: Frame, stmt: stmts.asinh):
         values = frame.get_values(stmt.args)
         return (
-            ilist.IList(np.asinh(np.asarray(values[0])).tolist(), elem=types.Float),
+            ilist.IList(np.arcsinh(np.asarray(values[0])).tolist(), elem=types.Float),
         )
 
     @impl(stmts.atan)
     def atan(self, interp, frame: Frame, stmt: stmts.atan):
         values = frame.get_values(stmt.args)
-        return (ilist.IList(np.atan(np.asarray(values[0])).tolist(), elem=types.Float),)
+        return (
+            ilist.IList(np.arctan(np.asarray(values[0])).tolist(), elem=types.Float),
+        )
 
     @impl(stmts.atan2)
     def atan2(self, interp, frame: Frame, stmt: stmts.atan2):
         values = frame.get_values(stmt.args)
         return (
             ilist.IList(
-                np.atan2(np.asarray(values[0]), np.asarray(values[1])).tolist(),
+                np.arctan2(np.asarray(values[0]), np.asarray(values[1])).tolist(),
                 elem=types.Float,
             ),
         )
@@ -48,7 +54,7 @@ class MathMethodTable(MethodTable):
     def atanh(self, interp, frame: Frame, stmt: stmts.atanh):
         values = frame.get_values(stmt.args)
         return (
-            ilist.IList(np.atanh(np.asarray(values[0])).tolist(), elem=types.Float),
+            ilist.IList(np.arctanh(np.asarray(values[0])).tolist(), elem=types.Float),
         )
 
     @impl(stmts.ceil)

--- a/test/dialects/vmath/test_basic.py
+++ b/test/dialects/vmath/test_basic.py
@@ -12,7 +12,7 @@ def acos_func(x):
 
 
 def test_acos():
-    truth = np.acos(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
+    truth = np.arccos(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     out = acos_func(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     assert isinstance(out, ilist.IList)
     assert out.elem == types.Float
@@ -25,7 +25,7 @@ def asin_func(x):
 
 
 def test_asin():
-    truth = np.asin(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
+    truth = np.arcsin(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     out = asin_func(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     assert isinstance(out, ilist.IList)
     assert out.elem == types.Float
@@ -38,7 +38,7 @@ def asinh_func(x):
 
 
 def test_asinh():
-    truth = np.asinh(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
+    truth = np.arcsinh(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     out = asinh_func(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     assert isinstance(out, ilist.IList)
     assert out.elem == types.Float
@@ -51,7 +51,7 @@ def atan_func(x):
 
 
 def test_atan():
-    truth = np.atan(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
+    truth = np.arctan(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     out = atan_func(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     assert isinstance(out, ilist.IList)
     assert out.elem == types.Float
@@ -64,7 +64,7 @@ def atan2_func(y, x):
 
 
 def test_atan2():
-    truth = np.atan2(
+    truth = np.arctan2(
         ilist.IList([0.42, 0.87, 0.32], elem=types.Float),
         ilist.IList([0.42, 0.87, 0.32], elem=types.Float),
     )
@@ -83,7 +83,7 @@ def atanh_func(x):
 
 
 def test_atanh():
-    truth = np.atanh(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
+    truth = np.arctanh(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     out = atanh_func(ilist.IList([0.42, 0.87, 0.32], elem=types.Float))
     assert isinstance(out, ilist.IList)
     assert out.elem == types.Float
@@ -368,7 +368,7 @@ def pow_func(x, y):
 
 
 def test_pow():
-    truth = np.pow(
+    truth = np.power(
         ilist.IList([0.42, 0.87, 0.32], elem=types.Float),
         3.33,
     )


### PR DESCRIPTION
The vmath dialect is using some of the API that only available to 2.x numpy. 

This PR fix that to make it compatible with 1.x