### PR TITLE
fix bug in registering interpreters with multiple keys

### DIFF
--- a/src/kirin/registry.py
+++ b/src/kirin/registry.py
@@ -96,6 +96,6 @@ class Registry:
                 for _, member in inspect.getmembers(dialect_table):
                     if isinstance(member, BoundedDef):
                         for sig in member.signature:
-                            registry[sig] = member
-                break
+                            if sig not in registry:
+                                registry[sig] = member
         return registry


### PR DESCRIPTION
When defining an interpreter with more than one key, the registry only registers methods from the method table corresponding to the first key and skips the rest. This should fix the issue while adding the correct precedence checks.