### PR TITLE
Adding specialization on method constants

### DIFF
--- a/src/kirin/dialects/py/constant.py
+++ b/src/kirin/dialects/py/constant.py
@@ -33,8 +33,13 @@ class Constant(ir.Statement, Generic[T]):
 
     # NOTE: we allow py.Constant take data.PyAttr too
     def __init__(self, value: T | ir.Data[T]) -> None:
-        if not isinstance(value, ir.Data):
+        if isinstance(value, ir.Method):
+            value = ir.PyAttr(
+                value, pytype=types.MethodType[list(value.arg_types), value.return_type]
+            )
+        elif not isinstance(value, ir.Data):
             value = ir.PyAttr(value)
+
         super().__init__(
             attributes={"value": value},
             result_types=(value.type,),

--- a/test/analysis/dataflow/typeinfer/test_inter_method.py
+++ b/test/analysis/dataflow/typeinfer/test_inter_method.py
@@ -1,7 +1,8 @@
 from pytest import mark
 
 from kirin import types
-from kirin.prelude import basic
+from kirin.prelude import basic, structural
+from kirin.dialects import ilist
 
 
 @mark.xfail(reason="if with early return not supported in scf lowering")
@@ -44,3 +45,16 @@ def test_infer_if_return():
         return b
 
     test.print()
+
+
+def test_method_constant_type_infer():
+
+    @structural(typeinfer=True, fold=False)
+    def _new(qid: int):
+        return 1
+
+    @structural(fold=False, typeinfer=True)
+    def alloc(n_iter: int):
+        return ilist.map(_new, ilist.range(n_iter))
+
+    assert alloc.return_type.is_subseteq(ilist.IListType[types.Literal(1), types.Any])


### PR DESCRIPTION
When constructing Methods as Python constants, the type defaulted to `PyClass`, which is incorrect and breaks type inference. 