### PR TITLE
Add docstrings for JSONSerializer. Addresses #520

### DIFF
--- a/src/kirin/dialects/func/attrs.py
+++ b/src/kirin/dialects/func/attrs.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from kirin import types
 from kirin.ir import Method, Attribute
 from kirin.print.printer import Printer
-from kirin.serialization.base.serializationunit import SerializationUnit
 
 if TYPE_CHECKING:
+    from kirin.serialization.base.serializationunit import SerializationUnit
     from kirin.serialization.base.serializer import Serializer
     from kirin.serialization.base.deserializer import Deserializer
 

--- a/src/kirin/dialects/ilist/runtime.py
+++ b/src/kirin/dialects/ilist/runtime.py
@@ -5,11 +5,11 @@ from collections.abc import Sequence
 
 from kirin import ir, types
 from kirin.print.printer import Printer
-from kirin.serialization.base.serializationunit import SerializationUnit
 
 if TYPE_CHECKING:
     from kirin.serialization.base.serializer import Serializer
     from kirin.serialization.base.deserializer import Deserializer
+    from kirin.serialization.base.serializationunit import SerializationUnit
 
 T = TypeVar("T")
 L = TypeVar("L")

--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -5,9 +5,9 @@ from typing_extensions import Protocol, runtime_checkable
 
 from kirin.print import Printer
 from kirin.ir.attrs.abc import Attribute
-from kirin.serialization.base.serializationunit import SerializationUnit
 
 if TYPE_CHECKING:
+    from kirin.serialization.base.serializationunit import SerializationUnit
     from kirin.serialization.base.serializer import Serializer
     from kirin.serialization.base.deserializer import Deserializer
 

--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -7,9 +7,8 @@ from collections.abc import Hashable
 from beartype.door import TupleVariableTypeHint  # type: ignore
 from beartype.door import TypeHint, ClassTypeHint, LiteralTypeHint, TypeVarTypeHint
 
-from kirin.serialization.base.serializationunit import SerializationUnit
-
 if TYPE_CHECKING:
+    from kirin.serialization.base.serializationunit import SerializationUnit
     from kirin.serialization.base.serializer import Serializer
     from kirin.serialization.base.deserializer import Deserializer
 

--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -581,12 +581,6 @@ class Statement(IRNode["Block"]):
             and other.parent is not None
             and context.get(self.parent) != other.parent
         ):
-            print(id(self.parent))
-            self.parent.print()
-            print(id(other.parent))
-            other.parent.print()
-            for c, v in context.items():
-                print("id:", id(c), "value:", id(v))
             return False
 
         if not all(

--- a/src/kirin/serialization/__init__.py
+++ b/src/kirin/serialization/__init__.py
@@ -1,3 +1,8 @@
+from .base.context import SerializationContext as SerializationContext
 from .jsonserializer import JSONSerializer as JSONSerializer
 from .base.serializer import Serializer as Serializer
 from .base.deserializer import Deserializer as Deserializer
+from .base.serializable import Serializable as Serializable
+from .base.deserializable import Deserializable as Deserializable
+from .base.serializationunit import SerializationUnit as SerializationUnit
+from .base.serializationmodule import SerializationModule as SerializationModule

--- a/src/kirin/serialization/__init__.py
+++ b/src/kirin/serialization/__init__.py
@@ -1,0 +1,3 @@
+from .jsonserializer import JSONSerializer as JSONSerializer
+from .base.serializer import Serializer as Serializer
+from .base.deserializer import Deserializer as Deserializer

--- a/src/kirin/serialization/__init__.py
+++ b/src/kirin/serialization/__init__.py
@@ -1,8 +1,14 @@
-from .base.context import SerializationContext as SerializationContext
-from .jsonserializer import JSONSerializer as JSONSerializer
-from .base.serializer import Serializer as Serializer
-from .base.deserializer import Deserializer as Deserializer
-from .base.serializable import Serializable as Serializable
-from .base.deserializable import Deserializable as Deserializable
-from .base.serializationunit import SerializationUnit as SerializationUnit
-from .base.serializationmodule import SerializationModule as SerializationModule
+from kirin.serialization.base.context import (
+    SerializationContext as SerializationContext,
+)
+from kirin.serialization.jsonserializer import JSONSerializer as JSONSerializer
+from kirin.serialization.base.serializer import Serializer as Serializer
+from kirin.serialization.base.deserializer import Deserializer as Deserializer
+from kirin.serialization.base.serializable import Serializable as Serializable
+from kirin.serialization.base.deserializable import Deserializable as Deserializable
+from kirin.serialization.base.serializationunit import (
+    SerializationUnit as SerializationUnit,
+)
+from kirin.serialization.base.serializationmodule import (
+    SerializationModule as SerializationModule,
+)

--- a/src/kirin/serialization/base/__init__.py
+++ b/src/kirin/serialization/base/__init__.py
@@ -1,0 +1,13 @@
+from .context import SerializationContext
+from .serializable import Serializable
+from .deserializable import Deserializable
+from .serializationunit import SerializationUnit
+from .serializationmodule import SerializationModule
+
+__all__ = [
+    "Serializable",
+    "Deserializable",
+    "SerializationContext",
+    "SerializationUnit",
+    "SerializationModule",
+]

--- a/src/kirin/serialization/base/serializationmodule.py
+++ b/src/kirin/serialization/base/serializationmodule.py
@@ -1,13 +1,16 @@
-from kirin.serialization.base.context import MethodSymbolMeta
-from kirin.serialization.base.serializationunit import SerializationUnit
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kirin.serialization.base.context import MethodSymbolMeta
+    from kirin.serialization.base.serializationunit import SerializationUnit
 
 
 class SerializationModule:
-    symbol_table: dict[str, MethodSymbolMeta]
-    body: SerializationUnit
+    symbol_table: dict[str, "MethodSymbolMeta"]
+    body: "SerializationUnit"
 
     def __init__(
-        self, symbol_table: dict[str, MethodSymbolMeta], body: SerializationUnit
+        self, symbol_table: dict[str, "MethodSymbolMeta"], body: "SerializationUnit"
     ):
         self.symbol_table = symbol_table
         self.body = body

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -6,6 +6,11 @@ from kirin.serialization.base.serializationmodule import SerializationModule
 
 
 class JSONSerializer:
+    """
+    JSON serializer/deserializer for SerializationModule
+    and SerializationUnit.
+    """
+
     def _to_jsonifiable(self, obj: Any) -> Any:
         if isinstance(obj, SerializationModule):
             return {
@@ -47,23 +52,25 @@ class JSONSerializer:
         return obj
 
     def encode(self, data: SerializationModule) -> str:
+        """
+        Top-level function to encode a SerializationModule to a JSON string.
+        Args:
+            data: SerializationModule to encode.
+        Returns:
+            JSON string representation of the SerializationModule.
+        """
         payload = self._to_jsonifiable(data)
         return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
 
     def decode(self, data: str) -> SerializationModule:
+        """
+        Top-level function to decode a JSON string to a SerializationModule.
+        Args:
+            data: JSON string to decode.
+        Returns:
+            Deserialized SerializationModule."""
         parsed = json.loads(data)
         result = self._from_jsonifiable(parsed)
         if not isinstance(result, SerializationModule):
             raise TypeError("decoded payload is not a SerializationModule")
         return result
-
-    def serialize_serialization_unit(self, unit: SerializationUnit) -> str:
-        payload = self._to_jsonifiable(unit)
-        return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
-
-    def deserialize_serialization_unit(self, data: str) -> SerializationUnit:
-        parsed = json.loads(data)
-        obj = self._from_jsonifiable(parsed)
-        if not isinstance(obj, SerializationUnit):
-            raise TypeError("decoded payload is not a SerializationUnit")
-        return obj


### PR DESCRIPTION
Address JSONSerializer's documentation error. Address #520 

* Added docstrings to the `JSONSerializer` class and its `encode` and `decode` methods.
* Removed the `serialize_serialization_unit` and `deserialize_serialization_unit` methods from `JSONSerializer` as they were redundant.
* Removed debug print statements from the `is_structurally_equal` method in `src/kirin/ir/nodes/stmt.py` .