### PR TITLE
serialize to/from json helper functions

### DIFF
--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -22,6 +22,7 @@ from typing_extensions import Self
 from kirin.ir.method import Method
 from kirin.ir.traits import SymbolTable, SymbolOpInterface
 from kirin.ir.exception import CompilerError, ValidationError
+from kirin.serialization.jsonserializer import get_json_serializer
 
 if TYPE_CHECKING:
     from kirin.ir import Method, Dialect, Statement
@@ -331,20 +332,12 @@ class DialectGroup(Generic[PassParams]):
         return deserializer.decode(encoded)
 
     def encode_json(self, program: Method) -> str:
-        from kirin.serialization.jsonserializer import JSONSerializer
-
         encoded_module = self.encode(program)
-        json_serializer = JSONSerializer()
-        json_str = json_serializer.encode(encoded_module)
-        return json_str
+        return get_json_serializer().encode(encoded_module)
 
     def decode_json(self, json_str: str) -> Method:
-        from kirin.serialization.jsonserializer import JSONSerializer
-
-        json_serializer = JSONSerializer()
-        decoded_module = json_serializer.decode(json_str)
-        program = self.decode(decoded_module)
-        return program
+        decoded_module = get_json_serializer().decode(json_str)
+        return self.decode(decoded_module)
 
 
 def dialect_group(

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Optional
 
 from kirin.serialization.core.serializationunit import SerializationUnit
 from kirin.serialization.core.serializationmodule import SerializationModule
@@ -74,3 +74,14 @@ class JSONSerializer:
         if not isinstance(result, SerializationModule):
             raise TypeError("decoded payload is not a SerializationModule")
         return result
+
+
+_json_serializer_instance: Optional[JSONSerializer] = None
+
+
+def get_json_serializer() -> JSONSerializer:
+    """Lazily return a single JSONSerializer instance (module-level singleton)."""
+    global _json_serializer_instance
+    if _json_serializer_instance is None:
+        _json_serializer_instance = JSONSerializer()
+    return _json_serializer_instance


### PR DESCRIPTION
Added helper functions so that EDSLs do not need to write their own to and from jsons.
Adds `encode_json` and `decode_json` methods to the `DialectGroup` class to and from JSON strings.
