### PR TITLE
Changed to use ValidationErrorGroup

### DIFF
--- a/src/kirin/ir/exception.py
+++ b/src/kirin/ir/exception.py
@@ -80,3 +80,11 @@ class DefiniteValidationError(ValidationError):
     """Indicates a definite violation that will occur at runtime."""
 
     pass
+
+
+class ValidationErrorGroup(BaseException):
+    """Container for multiple validation errors (Python 3.10+ compatible)."""
+
+    def __init__(self, message: str, errors: list[ValidationError]) -> None:
+        super().__init__(message)
+        self.errors = errors

--- a/src/kirin/validation/validationpass.py
+++ b/src/kirin/validation/validationpass.py
@@ -3,7 +3,7 @@ from typing import Any, Generic, TypeVar
 from dataclasses import field, dataclass
 
 from kirin import ir
-from kirin.ir.exception import ValidationError
+from kirin.ir.exception import ValidationError, ValidationErrorGroup
 
 T = TypeVar("T")
 
@@ -180,9 +180,8 @@ class ValidationResult:
         """Raise an exception if validation failed."""
         if not self.is_valid:
             exceptions = []
-            for pass_name, pass_errors in self.errors.items():
-                for err in pass_errors:
-                    exceptions.append(err)
+            for _, pass_errors in self.errors.items():
+                exceptions.extend(pass_errors)
 
             message = self._format_errors()
-            raise ExceptionGroup(message, exceptions)
+            raise ValidationErrorGroup(message, errors=exceptions)


### PR DESCRIPTION
This is using @david-pl's `ValidationErrorGroup`.
Due to Python 3.10 not having `ExceptionGroup`, moved David's `ValidationErrorGroup` to Kirin for handling multiple validation errors.