### PR TITLE
Lowering for syntax sugar for binop

### DIFF
--- a/test/lowering/test_hint_union_binop.py
+++ b/test/lowering/test_hint_union_binop.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from kirin import types
+from kirin.prelude import basic
+from kirin.dialects import ilist
+
+
+def test_method_union_binop_hint():
+
+    @basic
+    def main(x: ilist.IList[float, Any] | list[float]) -> float:
+        return x[0]
+
+    main.print()
+
+    tps = main.arg_types
+
+    assert len(tps) == 1
+    assert tps[0] == types.Union(
+        [ilist.IListType[types.Float, types.Any], types.List[types.Float]]
+    )
+
+
+def test_method_union_multi_hint():
+
+    @basic
+    def main(x: str | float | int):
+        return x
+
+    main.print()
+
+    tps = main.arg_types
+
+    assert len(tps) == 1
+    assert tps[0] == types.Union([types.String, types.Float, types.Int])


### PR DESCRIPTION
This PR expand the capability for lowering of kernel with type hint of something with:

```python

@basic
    def main(x: str | float | int):
        return x

    main.print()

    tps = main.arg_types

    assert len(tps) == 1
    assert tps[0] == types.Union([types.String, types.Float, types.Int])

```

Note that before this PR, only Binding can allow this semantic, but will error if one trying to do that for kernel program

