### PR TITLE
Fix guard in `ilist.FlattenAdd` to give up on `BottomType` inputs. 

### DIFF
--- a/src/kirin/dialects/ilist/rewrite/flatten_add.py
+++ b/src/kirin/dialects/ilist/rewrite/flatten_add.py
@@ -16,6 +16,9 @@ class FlattenAdd(RewriteRule):
         ):
             return RewriteResult()
 
+        assert isinstance(rhs_type, types.Generic), "Expecting generic type for IList"
+        assert isinstance(lhs_type, types.Generic), "Expecting generic type for IList"
+
         # check if we are adding two ilist.New objects
         new_data = ()
 
@@ -47,9 +50,6 @@ class FlattenAdd(RewriteRule):
             or len(const_rhs.data) > 0
         ):
             return RewriteResult()
-
-        assert isinstance(rhs_type := rhs.type, types.Generic), "Impossible"
-        assert isinstance(lhs_type := lhs.type, types.Generic), "Impossible"
 
         lhs_elem_type = lhs_type.vars[0]
         rhs_elem_type = rhs_type.vars[0]


### PR DESCRIPTION
Currently there are some cases where the assert `assert isinstance(lhs_type := lhs.type, types.Generic)` is False because `Bottom` is a subset of `IListType` in the type lattice. this PR adds some logic to make sure any Bottom types are skipped in this rewrite rule. 