### PR TITLE
Update beartype dependency version to >=0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The Kirin Toolchain for building compilers and interpreters."
 authors = [{ name = "Roger-luo", email = "rluo@quera.com" }]
 dependencies = [
     "rich>=13.7.1",
-    "beartype>=0.17.2",
+    "beartype>=0.19.0",
     "typing_extensions>=4.11.0",
 ]
 readme = "README.md"


### PR DESCRIPTION
`from beartype.door import TupleVariableTypeHint` was only added as of beartype version 0.19.0

Using beartype version <0.19 (e.g. 0.18.5) gives `ImportError` here:

https://github.com/QuEraComputing/kirin/blob/5345d809dcca4f86188c2f9f789751162fb29ebf/src/kirin/ir/attrs/types.py#L7