### PR TITLE
Neelay/fix post inference

### DIFF
--- a/src/kirin/dialects/vmath/rewrites/desugar.py
+++ b/src/kirin/dialects/vmath/rewrites/desugar.py
@@ -1,14 +1,13 @@
 from kirin import ir, types
-from kirin.rewrite import Walk
 from kirin.dialects.py import Add, Div, Sub, Mult, BinOp
 from kirin.rewrite.abc import RewriteRule, RewriteResult
-from kirin.ir.nodes.base import IRNode
 from kirin.dialects.ilist import IListType
 
 from ..stmts import add as vadd, div as vdiv, sub as vsub, mult as vmult
 from .._dialect import dialect
 
 
+@dialect.post_inference
 class DesugarBinOp(RewriteRule):
     """
     Convert py.BinOp statements with one scalar arg and one IList arg
@@ -55,14 +54,3 @@ class DesugarBinOp(RewriteRule):
                 return RewriteResult(has_done_something=True)
             case _:
                 return RewriteResult()
-
-
-@dialect.post_inference
-class WalkDesugarBinop(RewriteRule):
-    """
-    Walks DesugarBinop. Needed for correct behavior when
-    registering as a post-inference rewrite.
-    """
-
-    def rewrite(self, node: IRNode):
-        return Walk(DesugarBinOp()).rewrite(node)

--- a/src/kirin/passes/post_inference.py
+++ b/src/kirin/passes/post_inference.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from kirin.rewrite import Walk
 from kirin.ir.method import Method
 from kirin.rewrite.abc import RewriteResult
 
@@ -13,5 +14,5 @@ class PostInference(Pass):
         result = RewriteResult()
         for dialect in self.dialects:
             for rule in dialect.rules.inference:
-                result = rule.rewrite(mt.code).join(result)
+                result = Walk(rule).rewrite(mt.code).join(result)
         return result

--- a/test/analysis/dataflow/typeinfer/test_infer_lambda.py
+++ b/test/analysis/dataflow/typeinfer/test_infer_lambda.py
@@ -5,15 +5,15 @@ from kirin.dialects import ilist
 
 def test_infer_lambda():
     @structural(typeinfer=True, fold=False, no_raise=False)
-    def main(n):
+    def main(n, m: int):
         def map_func(i):
             return n + 1
 
-        return ilist.map(map_func, ilist.range(4))
+        return ilist.map(map_func, ilist.range(m))
 
     map_stmt = main.callable_region.blocks[0].stmts.at(-2)
     assert isinstance(map_stmt, ilist.Map)
-    assert map_stmt.result.type == ilist.IListType[types.Int, types.Literal(4)]
+    assert map_stmt.result.type == ilist.IListType[types.Int, types.Any]
 
 
 def test_infer_method_type_hint_call():


### PR DESCRIPTION
The post_inference pass (set of rewrite rules that runs after `TypeInfer`) was configured such that the registered rewrite rules would not actually walk the IR; this PR changes (`rule.rewrite(mt.code).join(result)`) to `Walk(rule).rewrite(mt.code).join(result)`). 