### PR TITLE
ConstProp early termination optimization

### DIFF
--- a/src/kirin/dialects/scf/constprop.py
+++ b/src/kirin/dialects/scf/constprop.py
@@ -108,14 +108,8 @@ class DialectConstProp(interp.MethodTable):
 
         loop_vars = frame.get_values(stmt.initializers)
 
-        # Early termination is only sound when the loop body does not
-        # reference the iteration variable.  When the body ignores it,
-        # each iteration is a pure function of loop_vars alone, so
-        # convergence of loop_vars implies all subsequent iterations
-        # are identical (including purity).  If the body *does* use the
-        # iteration variable, different iterations may follow different
-        # code paths (e.g. conditional side effects on a particular i),
-        # so we must execute every iteration.
+        # Only safe to break early when the body doesn't use the iteration
+        # variable — otherwise later iterations may take different code paths.
         iter_var = stmt.body.blocks[0].args[0]
         can_early_terminate = not iter_var.uses
 

--- a/src/kirin/dialects/scf/constprop.py
+++ b/src/kirin/dialects/scf/constprop.py
@@ -108,6 +108,17 @@ class DialectConstProp(interp.MethodTable):
 
         loop_vars = frame.get_values(stmt.initializers)
 
+        # Early termination is only sound when the loop body does not
+        # reference the iteration variable.  When the body ignores it,
+        # each iteration is a pure function of loop_vars alone, so
+        # convergence of loop_vars implies all subsequent iterations
+        # are identical (including purity).  If the body *does* use the
+        # iteration variable, different iterations may follow different
+        # code paths (e.g. conditional side effects on a particular i),
+        # so we must execute every iteration.
+        iter_var = stmt.body.blocks[0].args[0]
+        can_early_terminate = not iter_var.uses
+
         prev_loop_vars = None
         for value in iterable.data:
             with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
@@ -122,7 +133,11 @@ class DialectConstProp(interp.MethodTable):
             elif isinstance(loop_vars, interp.ReturnValue):
                 return loop_vars
 
-            if prev_loop_vars is not None and loop_vars == prev_loop_vars:
+            if (
+                can_early_terminate
+                and prev_loop_vars is not None
+                and loop_vars == prev_loop_vars
+            ):
                 break
             prev_loop_vars = loop_vars
 

--- a/src/kirin/dialects/scf/constprop.py
+++ b/src/kirin/dialects/scf/constprop.py
@@ -108,6 +108,7 @@ class DialectConstProp(interp.MethodTable):
 
         loop_vars = frame.get_values(stmt.initializers)
 
+        prev_loop_vars = None
         for value in iterable.data:
             with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
                 loop_vars = interp_.frame_call_region(
@@ -120,6 +121,10 @@ class DialectConstProp(interp.MethodTable):
                 loop_vars = ()
             elif isinstance(loop_vars, interp.ReturnValue):
                 return loop_vars
+
+            if prev_loop_vars is not None and loop_vars == prev_loop_vars:
+                break
+            prev_loop_vars = loop_vars
 
         if not frame_is_not_pure:
             frame.should_be_pure.add(stmt)

--- a/test/dialects/scf/test_constprop.py
+++ b/test/dialects/scf/test_constprop.py
@@ -137,15 +137,7 @@ def test_no_early_termination_when_body_uses_iter_var():
     constprop = const.Propagate(_group)
     frame, ret = constprop.run(impure_on_later_iter)
 
-    # The for-loop statement is in the first block of the callable region.
-    for_stmt = None
-    for block in impure_on_later_iter.callable_region.blocks:
-        for stmt in block.stmts:
-            if isinstance(stmt, scf.For):
-                for_stmt = stmt
-                break
-
-    assert for_stmt is not None, "Could not find scf.For in the IR"
+    [for_stmt] = [s for s in impure_on_later_iter.code.walk() if isinstance(s, scf.For)]
     # The for-loop must NOT be in should_be_pure — it contains a
     # conditionally-impure operation on a later iteration.
     assert for_stmt not in frame.should_be_pure

--- a/test/dialects/scf/test_constprop.py
+++ b/test/dialects/scf/test_constprop.py
@@ -119,8 +119,8 @@ def test_inside_return():
 def test_no_early_termination_when_body_uses_iter_var():
     """Early termination must not fire when the body references the iteration
     variable, because later iterations may follow different code paths that
-    affect purity.  Here the impure ``ImpureOp`` is guarded by ``i == 2``,
-    so the loop body is impure only on iteration 2.  If early termination
+    affect purity.  Here the impure ``ImpureOp`` is guarded by ``i == 50``,
+    so the loop body is impure only on iteration 50.  If early termination
     incorrectly broke after iteration 1 (where loop_vars converge), the
     for-loop would be marked as pure when it is not."""
 
@@ -128,8 +128,8 @@ def test_no_early_termination_when_body_uses_iter_var():
 
     @_group
     def impure_on_later_iter(x: int) -> int:
-        for i in range(5):
-            if i == 2:
+        for i in range(100):
+            if i == 50:
                 ImpureOp()
             x = x + 1
         return x

--- a/test/dialects/scf/test_constprop.py
+++ b/test/dialects/scf/test_constprop.py
@@ -116,6 +116,25 @@ def test_inside_return():
     assert value.data == 0
 
 
+def test_early_termination_when_body_ignores_iter_var():
+    """When the body doesn't reference the iteration variable and loop_vars
+    converge (x is Unknown, so Unknown + 1 = Unknown), early termination
+    should fire and produce the same result as running all iterations."""
+
+    @structural_no_opt
+    def converging_loop(x: int) -> int:
+        for _i in range(100):
+            x = x + 1
+        return x
+
+    constprop = const.Propagate(structural_no_opt)
+    frame, ret = constprop.run(converging_loop)
+
+    assert isinstance(ret, const.Unknown)
+    [for_stmt] = [s for s in converging_loop.code.walk() if isinstance(s, scf.For)]
+    assert for_stmt in frame.should_be_pure
+
+
 def test_no_early_termination_when_body_uses_iter_var():
     """Early termination must not fire when the body references the iteration
     variable, because later iterations may follow different code paths that

--- a/test/dialects/scf/test_constprop.py
+++ b/test/dialects/scf/test_constprop.py
@@ -1,10 +1,21 @@
 from pytest import mark
 
+from kirin import ir, lowering
+from kirin.decl import statement
 from kirin.prelude import structural_no_opt
 from kirin.analysis import const
 from kirin.dialects import scf, func
 
 prop = const.Propagate(structural_no_opt)
+
+# A statement with no Pure/MaybePure trait — acts as a side effect.
+_impure_dialect = ir.Dialect("test_impure")
+
+
+@statement(dialect=_impure_dialect)
+class ImpureOp(ir.Statement):
+    name = "impure_op"
+    traits = frozenset({lowering.FromPythonCall()})
 
 
 def test_simple_loop():
@@ -103,3 +114,38 @@ def test_inside_return():
     assert isinstance(terminator, func.Return)
     assert isinstance(value := frame.entries[terminator.value], const.Value)
     assert value.data == 0
+
+
+def test_no_early_termination_when_body_uses_iter_var():
+    """Early termination must not fire when the body references the iteration
+    variable, because later iterations may follow different code paths that
+    affect purity.  Here the impure ``ImpureOp`` is guarded by ``i == 2``,
+    so the loop body is impure only on iteration 2.  If early termination
+    incorrectly broke after iteration 1 (where loop_vars converge), the
+    for-loop would be marked as pure when it is not."""
+
+    _group = structural_no_opt.add(_impure_dialect)
+
+    @_group
+    def impure_on_later_iter(x: int) -> int:
+        for i in range(5):
+            if i == 2:
+                ImpureOp()
+            x = x + 1
+        return x
+
+    constprop = const.Propagate(_group)
+    frame, ret = constprop.run(impure_on_later_iter)
+
+    # The for-loop statement is in the first block of the callable region.
+    for_stmt = None
+    for block in impure_on_later_iter.callable_region.blocks:
+        for stmt in block.stmts:
+            if isinstance(stmt, scf.For):
+                for_stmt = stmt
+                break
+
+    assert for_stmt is not None, "Could not find scf.For in the IR"
+    # The for-loop must NOT be in should_be_pure — it contains a
+    # conditionally-impure operation on a later iteration.
+    assert for_stmt not in frame.should_be_pure


### PR DESCRIPTION
A (looser) form of this optimization exists in https://github.com/QuEraComputing/bloqade-circuit/pull/736. The idea is to stop constprop from iterating through a loop if `loop_vars` has converged, preventing a bunch of unnecessary future iterations. 

Claude pointed out to me that if there's some dependency on the iteration variable triggering an impure operation in the loop body, the original fix without the guard you currently see would improperly denote the loop as entirely pure. 

I already check for no iteration variable dependency in the bloqade-circuit stuff I'm working on but I don't see the harm in having it duplicated here. 

@Roger-luo agreed this optimization is worth including in Kirin, with kudos to @weinbe58 and @jasonhan3 for pointing this optimization out to me. 

Some benchmarks can be seen here, running against a trivial:

```python
@structural_no_opt
def loop_test(x: int) -> int:
	for _i in range(...):
		x = x + 1
	return x
```

From `range(10)` to `range(30_000)`:

<img width="1200" height="750" alt="bench_constprop_early_termination" src="https://github.com/user-attachments/assets/d5ba5321-b577-41a9-904e-841ce8ad7e50" />
