### PR TITLE
CompressedBSON serializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "rich>=13.7.1",
     "beartype>=0.19.0",
     "typing_extensions>=4.11.0",
+    "pymongo>=4.17.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/src/kirin/serialization/bsonserializer.py
+++ b/src/kirin/serialization/bsonserializer.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+import bson
+
+from kirin.serialization.core.serializationmodule import SerializationModule
+
+from .jsonserializer import JSONtifiable
+
+
+class BSONSerializer(JSONtifiable):
+
+    def encode(self, data: SerializationModule) -> bytes:
+        """
+        Top-level function to encode a SerializationModule to a BSON byte string.
+        Args:
+            data: SerializationModule to encode.
+        Returns:
+            BSON byte string representation of the SerializationModule.
+        """
+        payload = self._to_jsonifiable(data)
+        return bson.encode(payload)
+
+    def decode(self, data: bytes) -> SerializationModule:
+        """
+        Top-level function to decode a BSON byte string to a SerializationModule.
+        Args:
+            data: BSON byte string to decode.
+        Returns:
+            Deserialized SerializationModule."""
+        parsed = bson.decode(data)
+        result = self._from_jsonifiable(parsed)
+        if not isinstance(result, SerializationModule):
+            raise TypeError("decoded payload is not a SerializationModule")
+        return result
+
+
+_bson_serializer_instance: Optional[BSONSerializer] = None
+
+
+def get_bson_serializer() -> BSONSerializer:
+    """Lazily return a single BSONSerializer instance (module-level singleton)."""
+    global _bson_serializer_instance
+    if _bson_serializer_instance is None:
+        _bson_serializer_instance = BSONSerializer()
+    return _bson_serializer_instance

--- a/src/kirin/serialization/bsonserializer.py
+++ b/src/kirin/serialization/bsonserializer.py
@@ -1,3 +1,4 @@
+import gzip
 from typing import Optional
 
 import bson
@@ -7,7 +8,7 @@ from kirin.serialization.core.serializationmodule import SerializationModule
 from .jsonserializer import JSONtifiable
 
 
-class BSONSerializer(JSONtifiable):
+class CompressedBSONSerializer(JSONtifiable):
 
     def encode(self, data: SerializationModule) -> bytes:
         """
@@ -18,7 +19,7 @@ class BSONSerializer(JSONtifiable):
             BSON byte string representation of the SerializationModule.
         """
         payload = self._to_jsonifiable(data)
-        return bson.encode(payload)
+        return gzip.compress(bson.encode(payload))
 
     def decode(self, data: bytes) -> SerializationModule:
         """
@@ -27,19 +28,19 @@ class BSONSerializer(JSONtifiable):
             data: BSON byte string to decode.
         Returns:
             Deserialized SerializationModule."""
-        parsed = bson.decode(data)
+        parsed = bson.decode(gzip.decompress(data))
         result = self._from_jsonifiable(parsed)
         if not isinstance(result, SerializationModule):
             raise TypeError("decoded payload is not a SerializationModule")
         return result
 
 
-_bson_serializer_instance: Optional[BSONSerializer] = None
+_bson_serializer_instance: Optional[CompressedBSONSerializer] = None
 
 
-def get_bson_serializer() -> BSONSerializer:
-    """Lazily return a single BSONSerializer instance (module-level singleton)."""
+def get_bson_serializer() -> CompressedBSONSerializer:
+    """Lazily return a single CompressedBSONSerializer instance (module-level singleton)."""
     global _bson_serializer_instance
     if _bson_serializer_instance is None:
-        _bson_serializer_instance = BSONSerializer()
+        _bson_serializer_instance = CompressedBSONSerializer()
     return _bson_serializer_instance

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -5,10 +5,10 @@ from kirin.serialization.core.serializationunit import SerializationUnit
 from kirin.serialization.core.serializationmodule import SerializationModule
 
 
-class JSONSerializer:
+class JSONtifiable:
     """
-    JSON serializer/deserializer for SerializationModule
-    and SerializationUnit.
+    Helper class to convert between SerializationModule/SerializationUnit and JSON-serializable dicts.
+    This is used internally by JSONSerializer and BSONSerializer to handle the actual conversion logic.
     """
 
     def _to_jsonifiable(self, obj: Any) -> Any:
@@ -50,6 +50,13 @@ class JSONSerializer:
         if isinstance(obj, list):
             return [self._from_jsonifiable(v) for v in obj]
         return obj
+
+
+class JSONSerializer(JSONtifiable):
+    """
+    JSON serializer/deserializer for SerializationModule
+    and SerializationUnit.
+    """
 
     def encode(self, data: SerializationModule) -> str:
         """

--- a/test/serialization/test_bsonserializer.py
+++ b/test/serialization/test_bsonserializer.py
@@ -1,0 +1,138 @@
+from kirin.prelude import basic
+from kirin.dialects import ilist
+from kirin.serialization.bsonserializer import BSONSerializer
+
+
+@basic
+def foo(x: int, y: float, z: bool):
+    c = [[(200.0, 200.0), (210.0, 200.0)]]
+    if z:
+        c = [(222.0, 333.0)]
+    else:
+        return [1, 2, 3, 4]
+    return c
+
+
+@basic
+def bar():
+    def goo(x: int):
+        a = (3, 4)
+        return a[0]
+
+    def boo(y):
+        return goo(y) + 1
+
+    boo(4)
+
+
+@basic
+def loop_ilist():
+    a = 0
+    c = ilist.IList([a, a * 2])
+    for i in range(3):
+        a = i
+        c = ilist.IList([a, a * 2])
+    return c
+
+
+@basic
+def my_kernel1(x: int):
+    return (x, x + 1, 3)
+
+
+@basic
+def my_kernel2(y: int):
+    return my_kernel1(y) * 10
+
+
+@basic
+def foo2(y: int):
+
+    def inner(x: int):
+        return x * y + 1
+
+    return inner
+
+
+inner_ker = foo2(y=10)
+
+
+@basic
+def main_lambda(z: int):
+    return inner_ker(z)
+
+
+@basic
+def slicing():
+    in1 = ("a", "b", "c", "d", "e", "f", "g", "h")
+    in2 = [1, 2, 3, 4, 5]
+
+    x = slice(3, 5)
+    a = in2[x]
+    b = in1[1:4]
+    c = in1[:3]
+    d = in1[2:]
+    e = in1[:]
+    return (a, b, c, d, e)
+
+
+def round_trip(program):
+    encoded = basic.encode(program)
+    decoded = basic.decode(encoded)
+    assert decoded.code.is_structurally_equal(program.code)
+    bson_serializer = BSONSerializer()
+    bson_encoded = bson_serializer.encode(encoded)
+    assert isinstance(bson_encoded, bytes)
+    bson_decoded = bson_serializer.decode(bson_encoded)
+    decoded_2 = basic.decode(bson_decoded)
+    assert decoded_2.code.is_structurally_equal(program.code)
+
+
+def test_round_trip1():
+    round_trip(foo)
+
+
+def test_round_trip2():
+    round_trip(bar)
+
+
+def test_round_trip3():
+    round_trip(loop_ilist)
+
+
+def test_round_trip4():
+    round_trip(my_kernel2)
+
+
+def test_round_trip5():
+    round_trip(slicing)
+
+
+def test_round_trip6():
+    round_trip(main_lambda)
+
+
+def test_deterministic():
+    s1 = basic.encode(loop_ilist)
+    bson_serializer = BSONSerializer()
+    bson_s1 = bson_serializer.encode(s1)
+    s2 = basic.encode(loop_ilist)
+    bson_serializer2 = BSONSerializer()
+    bson_s2 = bson_serializer2.encode(s2)
+    assert bson_s1 == bson_s2
+
+
+def test_eq():
+    @basic
+    def main():
+        x = 0
+        return x
+
+    bson_serializer = BSONSerializer()
+    bson_bytes = bson_serializer.encode(basic.encode(main))
+
+    bson_serializer = BSONSerializer()
+    main_des = basic.decode(bson_serializer.decode(bson_bytes))
+
+    # without run_passes, we get errors in e.g. main == main_des
+    assert hasattr(main_des, "run_passes")

--- a/test/serialization/test_bsonserializer.py
+++ b/test/serialization/test_bsonserializer.py
@@ -1,6 +1,6 @@
 from kirin.prelude import basic
 from kirin.dialects import ilist
-from kirin.serialization.bsonserializer import BSONSerializer
+from kirin.serialization.bsonserializer import CompressedBSONSerializer
 
 
 @basic
@@ -80,7 +80,7 @@ def round_trip(program):
     encoded = basic.encode(program)
     decoded = basic.decode(encoded)
     assert decoded.code.is_structurally_equal(program.code)
-    bson_serializer = BSONSerializer()
+    bson_serializer = CompressedBSONSerializer()
     bson_encoded = bson_serializer.encode(encoded)
     assert isinstance(bson_encoded, bytes)
     bson_decoded = bson_serializer.decode(bson_encoded)
@@ -114,10 +114,10 @@ def test_round_trip6():
 
 def test_deterministic():
     s1 = basic.encode(loop_ilist)
-    bson_serializer = BSONSerializer()
+    bson_serializer = CompressedBSONSerializer()
     bson_s1 = bson_serializer.encode(s1)
     s2 = basic.encode(loop_ilist)
-    bson_serializer2 = BSONSerializer()
+    bson_serializer2 = CompressedBSONSerializer()
     bson_s2 = bson_serializer2.encode(s2)
     assert bson_s1 == bson_s2
 
@@ -128,10 +128,10 @@ def test_eq():
         x = 0
         return x
 
-    bson_serializer = BSONSerializer()
+    bson_serializer = CompressedBSONSerializer()
     bson_bytes = bson_serializer.encode(basic.encode(main))
 
-    bson_serializer = BSONSerializer()
+    bson_serializer = CompressedBSONSerializer()
     main_des = basic.decode(bson_serializer.decode(bson_bytes))
 
     # without run_passes, we get errors in e.g. main == main_des


### PR DESCRIPTION
This PR add CompressedBSON serializer. 

Compare to JSON, it reduce the serialized file content size to ~20x


The following benchmark code with bloqade-circuit with 71.4kB (Json) v.s. 3.6kB (CompressedBson, this PR) 
```python 
from bloqade.gemini import logical
from bloqade import squin


@logical.kernel(aggressive_unroll=True)
def main():
    q = squin.qalloc(2)
    squin.h(q[0])
    squin.cx(q[0], q[1])
    return logical.terminal_measure(q)


# serialization test
from kirin.serialization.jsonserializer import JSONSerializer
from kirin.serialization.bsonserializer import CompressedBSONSerializer



encoded = logical.kernel.encode(main)

json_s = JSONSerializer().encode(encoded)
bson_b = CompressedBSONSerializer().encode(encoded)

with open("main.json", "w") as f:
    f.write(json_s)

with open("main.bson", "wb") as f:
    f.write(bson_b)

json_decoded = JSONSerializer().decode(json_s)
bson_decoded = CompressedBSONSerializer().decode(bson_b)

decoded = logical.kernel.decode(json_decoded)
decoded.print()
decoded = logical.kernel.decode(bson_decoded)
decoded.print()
```

cc
@Roger-luo @david-pl 