### PR TITLE
fix: CI for dependabot PRs and current main lint break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         # For example, using `pytest`
         run: uv run just coverage
       - name: Upload Coverage to Codecov
+        # Skip on forks / dependabot where CODECOV_TOKEN isn't exposed.
+        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codecov/codecov-action@v6
         with:
           files: coverage.xml # optional
@@ -55,7 +57,7 @@ jobs:
   post:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event.pull_request
+    if: github.event.pull_request && github.actor != 'dependabot[bot]'
     steps:
         - uses: actions/checkout@v6
         - name: download covearge

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,6 +14,8 @@ jobs:
   documentation:
     name: Deploy preview documentation
     runs-on: ubuntu-latest
+    # Dependabot PRs and forks don't get write access to gh-pages or required secrets.
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
       - name: Install uv

--- a/src/kirin/analysis/typeinfer/analysis.py
+++ b/src/kirin/analysis/typeinfer/analysis.py
@@ -54,8 +54,7 @@ class TypeInference(Forward[types.TypeAttribute]):
             signature: Signature[types.TypeAttribute] | None = trait.get_signature(node)
             if signature is not None:
                 args = (args[0],) + tuple(
-                    input.meet(arg)
-                    for input, arg in zip(signature.inputs, args[1:])
+                    input.meet(arg) for input, arg in zip(signature.inputs, args[1:])
                 )
         else:
             signature = None

--- a/src/kirin/interp/abc.py
+++ b/src/kirin/interp/abc.py
@@ -19,7 +19,6 @@ from .value import (
     YieldValue,
     ReturnValue,
     RegionResult,
-    SpecialValue,
     StatementResult,
 )
 from .exceptions import InterpreterError, StackOverflowError

--- a/src/kirin/interp/abc.py
+++ b/src/kirin/interp/abc.py
@@ -295,8 +295,10 @@ class InterpreterABC(ABC, Generic[FrameType, ValueType]):
         method = self.lookup_registry(frame, node)
         if method is not None:
             results = method(self, frame, node)
-            if self.debug and results is not None and not isinstance(
-                results, (tuple, ReturnValue, YieldValue, Successor)
+            if (
+                self.debug
+                and results is not None
+                and not isinstance(results, (tuple, ReturnValue, YieldValue, Successor))
             ):
                 raise InterpreterError(
                     f"method must return tuple or SpecialResult, got {results}"


### PR DESCRIPTION
## Summary
- Fix ruff F401: unused `SpecialValue` import in `src/kirin/interp/abc.py`
- Reformat `src/kirin/analysis/typeinfer/analysis.py` per black (currently failing on main)
- Skip Codecov upload + `post` job for dependabot PRs (no `CODECOV_TOKEN` exposed)
- Skip docs preview deploy for dependabot / forks (no `GH_TOKEN`, no gh-pages write)

This unblocks merging the open dependabot PRs (#636, #647) which currently fail CI only due to inability to access secrets.

## Test plan
- [x] `uv run ruff check src/kirin/interp/abc.py`
- [x] `uv run black --check src/kirin/analysis/typeinfer/analysis.py`
- [ ] CI passes on this PR
- [ ] After merge, rebase #636 / #647 and verify their CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)