### PR TITLE
ci: skip post coverage comment on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
   post:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event.pull_request && github.actor != 'dependabot[bot]'
+    # Skip on forks (read-only GITHUB_TOKEN can't post PR comments) and dependabot.
+    if: github.event.pull_request && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
         - uses: actions/checkout@v6
         - name: download covearge


### PR DESCRIPTION
## Summary
Fork PRs (e.g. #633) run with a read-only \`GITHUB_TOKEN\`, so \`orgoro/coverage\` fails with \`Resource not accessible by integration\` when trying to post a PR comment. Skip the \`post\` job on fork PRs (and we already skip dependabot).

## Test plan
- [ ] CI passes here (same-repo branch)
- [ ] After merge, rebase #633 (fork) and confirm \`post\` is skipped, not failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)