### PR TITLE
Add version field to serialization module

### DIFF
--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -323,11 +323,11 @@ class DialectGroup(Generic[PassParams]):
     ) -> Self:
         return cast(Self, deserializer.deserialize_dialect_group(serUnit))
 
-    def encode(self, program) -> "SerializationModule":
+    def encode(self, program, version: str = "") -> "SerializationModule":
         from kirin.serialization.base.serializer import Serializer
 
         serializer = Serializer()
-        return serializer.encode(program)
+        return serializer.encode(program, version)
 
     def decode(self, encoded: "SerializationModule") -> Method:
         from kirin.serialization.base.deserializer import Deserializer
@@ -335,12 +335,20 @@ class DialectGroup(Generic[PassParams]):
         deserializer = Deserializer(dialect_group=self)
         return deserializer.decode(encoded)
 
-    def encode_json(self, program: Method) -> str:
-        encoded_module = self.encode(program)
+    def encode_json(self, program: Method, version: str = "") -> str:
+        encoded_module = self.encode(program, version)
         return get_json_serializer().encode(encoded_module)
 
-    def decode_json(self, json_str: str) -> Method:
-        decoded_module = get_json_serializer().decode(json_str)
+    def decode_json(self, json_str: str, expect_version: str | None = None) -> Method:
+        serializer = get_json_serializer()
+        decoded_module = serializer.decode(json_str)
+        if (
+            expect_version is not None
+            and decoded_module.check_version(expect_version) is False
+        ):
+            raise ValueError(
+                f"Version mismatch: expected {expect_version}, got {decoded_module.version}"
+            )
         return self.decode(decoded_module)
 
 

--- a/src/kirin/serialization/base/serializer.py
+++ b/src/kirin/serialization/base/serializer.py
@@ -17,7 +17,7 @@ from kirin.serialization.core.serializationmodule import SerializationModule
 class Serializer:
     _ctx: SerializationContext = field(default_factory=SerializationContext, init=False)
 
-    def encode(self, obj: ir.Method) -> SerializationModule:
+    def encode(self, obj: ir.Method, version: str = "") -> SerializationModule:
         self._ctx.clear()
         body = self.serialize_method(obj)
         if getattr(self._ctx, "Method_Symbol", None):
@@ -37,7 +37,9 @@ class Serializer:
             symbol_table: dict[str, MethodSymbolMeta] = st
         else:
             symbol_table = dict[str, MethodSymbolMeta]()
-        return SerializationModule(symbol_table=symbol_table, body=body)
+        return SerializationModule(
+            symbol_table=symbol_table, body=body, version=version
+        )
 
     def serialize(
         self,

--- a/src/kirin/serialization/core/serializationmodule.py
+++ b/src/kirin/serialization/core/serializationmodule.py
@@ -8,9 +8,17 @@ if TYPE_CHECKING:
 class SerializationModule:
     symbol_table: dict[str, "MethodSymbolMeta"]
     body: "SerializationUnit"
+    version: str
 
     def __init__(
-        self, symbol_table: dict[str, "MethodSymbolMeta"], body: "SerializationUnit"
+        self,
+        symbol_table: dict[str, "MethodSymbolMeta"],
+        body: "SerializationUnit",
+        version: str = "",
     ):
         self.symbol_table = symbol_table
         self.body = body
+        self.version = version
+
+    def check_version(self, expect_version: str) -> bool:
+        return self.version == expect_version

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -15,6 +15,7 @@ class JSONtifiable:
         if isinstance(obj, SerializationModule):
             return {
                 "__serialization_module__": True,
+                "version": obj.version,
                 "symbol_table": self._to_jsonifiable(obj.symbol_table),
                 "body": self._to_jsonifiable(obj.body),
             }
@@ -37,7 +38,10 @@ class JSONtifiable:
             if obj.get("__serialization_module__"):
                 symbol_table = self._from_jsonifiable(obj.get("symbol_table", {}))
                 body = self._from_jsonifiable(obj.get("body"))
-                return SerializationModule(symbol_table=symbol_table, body=body)
+                version = obj.get("version", "")
+                return SerializationModule(
+                    symbol_table=symbol_table, body=body, version=version
+                )
             if obj.get("__serialization_unit__"):
                 data = self._from_jsonifiable(obj.get("data", {}))
                 return SerializationUnit(

--- a/test/serialization/test_version.py
+++ b/test/serialization/test_version.py
@@ -1,0 +1,102 @@
+import pytest
+
+from kirin.prelude import basic
+from kirin.serialization.jsonserializer import JSONSerializer
+from kirin.serialization.base.serializer import Serializer
+from kirin.serialization.core.serializationmodule import SerializationModule
+
+
+@basic
+def simple_kernel(x: int):
+    return x + 1
+
+
+def _empty_module(version: str = "") -> SerializationModule:
+    encoded = basic.encode(simple_kernel)
+    return SerializationModule(
+        symbol_table=encoded.symbol_table, body=encoded.body, version=version
+    )
+
+
+def test_serialization_module_default_version_is_empty():
+    mod = SerializationModule(symbol_table={}, body=basic.encode(simple_kernel).body)
+    assert mod.version == ""
+
+
+def test_serialization_module_stores_version():
+    mod = _empty_module(version="1.2.3")
+    assert mod.version == "1.2.3"
+
+
+def test_check_version_match():
+    mod = _empty_module(version="1.0.0")
+    assert mod.check_version("1.0.0") is True
+
+
+def test_check_version_mismatch():
+    mod = _empty_module(version="1.0.0")
+    assert mod.check_version("2.0.0") is False
+
+
+def test_check_version_against_empty():
+    mod = _empty_module(version="")
+    assert mod.check_version("") is True
+    assert mod.check_version("1.0.0") is False
+
+
+def test_serializer_encode_default_version():
+    serializer = Serializer()
+    mod = serializer.encode(simple_kernel)
+    assert mod.version == ""
+
+
+def test_serializer_encode_propagates_version():
+    serializer = Serializer()
+    mod = serializer.encode(simple_kernel, version="2.5.0")
+    assert mod.version == "2.5.0"
+
+
+def test_dialect_group_encode_default_version():
+    mod = basic.encode(simple_kernel)
+    assert mod.version == ""
+
+
+def test_dialect_group_encode_with_version():
+    mod = basic.encode(simple_kernel, version="3.1.4")
+    assert mod.version == "3.1.4"
+
+
+def test_encode_json_round_trips_version():
+    json_str = basic.encode_json(simple_kernel, version="0.9.0")
+    decoded_module = JSONSerializer().decode(json_str)
+    assert decoded_module.version == "0.9.0"
+
+
+def test_decode_json_no_expected_version_succeeds():
+    json_str = basic.encode_json(simple_kernel, version="1.0.0")
+    method = basic.decode_json(json_str)
+    assert method.code.is_structurally_equal(simple_kernel.code)
+
+
+def test_decode_json_expected_version_match():
+    json_str = basic.encode_json(simple_kernel, version="1.0.0")
+    method = basic.decode_json(json_str, expect_version="1.0.0")
+    assert method.code.is_structurally_equal(simple_kernel.code)
+
+
+def test_decode_json_expected_version_mismatch_raises():
+    json_str = basic.encode_json(simple_kernel, version="1.0.0")
+    with pytest.raises(ValueError, match="Version mismatch"):
+        basic.decode_json(json_str, expect_version="2.0.0")
+
+
+def test_decode_json_expected_version_against_default_empty():
+    json_str = basic.encode_json(simple_kernel)
+    with pytest.raises(ValueError, match="Version mismatch"):
+        basic.decode_json(json_str, expect_version="1.0.0")
+
+
+def test_decode_json_expected_empty_matches_default():
+    json_str = basic.encode_json(simple_kernel)
+    method = basic.decode_json(json_str, expect_version="")
+    assert method.code.is_structurally_equal(simple_kernel.code)


### PR DESCRIPTION
## Summary
- Add `version: str` field to `SerializationModule` with `check_version()` helper
- Thread `version` through `Serializer.encode`, `DialectGroup.encode`, and `DialectGroup.encode_json`
- Add `expect_version` argument to `DialectGroup.decode_json` that raises `ValueError` on mismatch
- Preserve `version` through `JSONtifiable._to_jsonifiable` / `_from_jsonifiable` so JSON and BSON round-trips don't drop it
- Add `test/serialization/test_version.py` with 15 tests covering module-level storage, encoder propagation, JSON round-trip, and `expect_version` match/mismatch
