### PR TITLE
fix(types.py): Addint is_subseteq_TypeVar to FunctionType to make sure it will be compabitle with generics

### DIFF
--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -881,6 +881,9 @@ class FunctionType(TypeAttribute):
     def is_subseteq_Union(self, other: Union) -> bool:
         return any(self.is_subseteq(t) for t in other.types)
 
+    def is_subseteq_TypeVar(self, other: "TypeVar") -> bool:
+        return self.is_subseteq(other.bound)
+
     def is_subseteq_fallback(self, other: TypeAttribute) -> bool:
         return False
 

--- a/test/lowering/test_657.py
+++ b/test/lowering/test_657.py
@@ -1,0 +1,19 @@
+from kirin.prelude import basic
+from kirin.dialects import ilist
+
+
+def test_657():
+
+    @basic
+    def main():
+        return 3
+
+    @basic
+    def main2():
+        return 4
+
+    @basic
+    def main_final():
+        return [main, main2]
+
+    assert main_final() == ilist.IList([main, main2])


### PR DESCRIPTION
Related issue #656 The problem there is when the FunctionType interaces with the IList Generic type it exposed that we're missing a visitor for `is_subseteq_TypeVar` because during lowering we haven't inferred the type yet. 