### PR TITLE
docs(faq): Add FAQ section and class methods explanation

### DIFF
--- a/docs/faq/class_methods.md
+++ b/docs/faq/class_methods.md
@@ -1,0 +1,63 @@
+# Calling Python Class Methods Inside a Kernel
+
+## The problem
+
+If you try to call a standard Python class method, such as
+`self.get_move_kernel()`, from inside a function decorated with
+`@kirin_flair.kernel` or `@kernel`, the compiler will fail. Historically, before
+Kirin v0.16.8, this could appear as an `AttributeError` about `arg_names`.
+
+## Why this happens
+
+A kernel is a piece of code that describes instructions intended to run on the
+target device, not on your host machine. Because of this, the Kirin compiler
+cannot evaluate arbitrary Python runtime expressions, such as object attribute
+lookups or dynamically calling class methods, during device execution.
+
+The compiler only parses global constants and already-resolved kernel functions.
+
+## The solution
+
+Resolve the Python method on the host before defining the kernel. By assigning
+the result to a local variable, the inner kernel can cleanly capture that
+variable as a constant.
+
+### Incorrect
+
+This tries to evaluate the method inside the device kernel.
+
+```python
+class Foo:
+    def get_move_buffer_kernel(self):
+
+        @kernel
+        def get_move_buffer():
+            # ERROR: Kirin cannot evaluate arbitrary Python class methods.
+            move_kernel = self.get_move_kernel()
+            move_sequence = move_kernel()
+            # ...
+            return bufr
+
+        return get_move_buffer
+```
+
+### Correct
+
+Resolve the method on the host side, then capture it in the kernel closure.
+
+```python
+class Foo:
+    def get_move_buffer_kernel(self):
+        # 1. Resolve the method in host Python code.
+        move_kernel = self.get_move_kernel()
+
+        # 2. Define the device kernel.
+        @kernel
+        def get_move_buffer(a, b, c):
+            # 3. Call the captured constant inside the kernel.
+            move_kernel(a, b, c)
+            # ...
+            return bufr
+
+        return get_move_buffer
+```

--- a/docs/faq/class_methods.md
+++ b/docs/faq/class_methods.md
@@ -4,8 +4,8 @@
 
 If you try to call a standard Python class method, such as
 `self.get_move_kernel()`, from inside a function decorated with
-`@kirin_flair.kernel` or `@kernel`, the compiler will fail. Historically, before
-Kirin v0.16.8, this could appear as an `AttributeError` about `arg_names`.
+`@basic` or `@structural`, the compiler will fail. Historically, before Kirin
+v0.16.8, this could appear as an `AttributeError` about `arg_names`.
 
 ## Why this happens
 
@@ -27,18 +27,23 @@ variable as a constant.
 This tries to evaluate the method inside the device kernel.
 
 ```python
-class Foo:
-    def get_move_buffer_kernel(self):
+from kirin.prelude import basic
 
-        @kernel
-        def get_move_buffer():
+
+class Offset:
+    def __init__(self, value: int):
+        self.value = value
+
+    def get_value(self) -> int:
+        return self.value
+
+    def bad_method(self):
+        @basic
+        def add_offset(x: int) -> int:
             # ERROR: Kirin cannot evaluate arbitrary Python class methods.
-            move_kernel = self.get_move_kernel()
-            move_sequence = move_kernel()
-            # ...
-            return bufr
+            return x + self.get_value()
 
-        return get_move_buffer
+        return add_offset
 ```
 
 ### Correct
@@ -46,18 +51,25 @@ class Foo:
 Resolve the method on the host side, then capture it in the kernel closure.
 
 ```python
-class Foo:
-    def get_move_buffer_kernel(self):
+from kirin.prelude import basic
+
+
+class Offset:
+    def __init__(self, value: int):
+        self.value = value
+
+    def get_value(self) -> int:
+        return self.value
+
+    def method(self):
         # 1. Resolve the method in host Python code.
-        move_kernel = self.get_move_kernel()
+        offset = self.get_value()
 
         # 2. Define the device kernel.
-        @kernel
-        def get_move_buffer(a, b, c):
-            # 3. Call the captured constant inside the kernel.
-            move_kernel(a, b, c)
-            # ...
-            return bufr
+        @basic
+        def add_offset(x: int) -> int:
+            # 3. Use the captured constant inside the kernel.
+            return x + offset
 
-        return get_move_buffer
+        return add_offset
 ```

--- a/docs/faq/class_methods.md
+++ b/docs/faq/class_methods.md
@@ -3,7 +3,7 @@
 ## The problem
 
 If you try to call a standard Python class method, such as
-`self.get_move_kernel()`, from inside a function decorated with
+`self.get_value()`, from inside a function decorated with
 `@basic` or `@structural`, the compiler will fail. Historically, before Kirin
 v0.16.8, this could appear as an `AttributeError` about `arg_names`.
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -1,0 +1,9 @@
+# FAQ
+
+This page collects common questions with a short answer and a link to a deeper explanation.
+
+## Kernel authoring
+
+| Question | Short answer |
+| --- | --- |
+| [Why do I get an `AttributeError` when calling a class method inside a kernel?](class_methods.md) | Resolve the Python method on the host side before defining the kernel, then capture it as a constant. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,9 @@ nav:
         - Structural Control Flow: dialects/scf.md
         - Immutable List: dialects/ilist.md
       - Compiler 101: 101.md
+      - FAQ:
+        - faq/index.md
+        - Class methods in kernels: faq/class_methods.md
       # - Comparison: comparison.md
       - Contributing: contrib.md
   - Cookbook:


### PR DESCRIPTION
Adds a new FAQ section to the docs with an index page and a first deep-dive entry about calling Python class methods inside kernels.

## Changes

- Adds `docs/faq/index.md` as a compact categorized FAQ landing page
- Adds `docs/faq/class_methods.md` explaining why class methods should be resolved on the host side before being captured by a kernel

cc: @kaihsin @Roger-luo