### PR TITLE
Backport #657 to release-0-22

### DIFF
--- a/src/kirin/ir/attrs/types.py
+++ b/src/kirin/ir/attrs/types.py
@@ -881,6 +881,9 @@ class FunctionType(TypeAttribute):
     def is_subseteq_Union(self, other: Union) -> bool:
         return any(self.is_subseteq(t) for t in other.types)
 
+    def is_subseteq_TypeVar(self, other: "TypeVar") -> bool:
+        return self.is_subseteq(other.bound)
+
     def is_subseteq_fallback(self, other: TypeAttribute) -> bool:
         return False
 

--- a/test/lowering/test_657.py
+++ b/test/lowering/test_657.py
@@ -1,0 +1,19 @@
+from kirin.prelude import basic
+from kirin.dialects import ilist
+
+
+def test_657():
+
+    @basic
+    def main():
+        return 3
+
+    @basic
+    def main2():
+        return 4
+
+    @basic
+    def main_final():
+        return [main, main2]
+
+    assert main_final() == ilist.IList([main, main2])


### PR DESCRIPTION
Backports #657 onto the 0.22 release line.

This cherry-picks the FunctionType TypeVar subset fix from main into release-0-22 so it can be included in the next 0.22 patch release.

Validation:
- uv run pytest test/lowering/test_657.py