### PR TITLE
Simplify toy liveness analysis

### DIFF
--- a/crates/kirin-ir/src/builder/stage_info.rs
+++ b/crates/kirin-ir/src/builder/stage_info.rs
@@ -236,10 +236,12 @@ impl<L: Dialect> BuilderStageInfo<L> {
             },
             |_info| None,
         );
-        Ok(StageInfo {
+        let mut stage = StageInfo {
             nodes: self.nodes,
             ssas,
-        })
+        };
+        stage.rebuild_use_index();
+        Ok(stage)
     }
 
     /// Convert to [`StageInfo`] without validation.
@@ -279,10 +281,12 @@ impl<L: Dialect> BuilderStageInfo<L> {
             // Deleted items become None tombstones — safe, no zeroed memory.
             |_info| None,
         );
-        StageInfo {
+        let mut stage = StageInfo {
             nodes: self.nodes,
             ssas,
-        }
+        };
+        stage.rebuild_use_index();
+        stage
     }
 }
 

--- a/crates/kirin-ir/src/lib.rs
+++ b/crates/kirin-ir/src/lib.rs
@@ -37,7 +37,7 @@ pub use node::{
     GraphInfo, LinkedList, LinkedListNode, Port, PortParent, ResolutionInfo, ResultValue, SSAInfo,
     SSAKind, SSAValue, SpecializedFunction, SpecializedFunctionInfo, StagedFunction,
     StagedFunctionInfo, StagedNamePolicy, Statement, StatementInfo, StatementParent, Successor,
-    Symbol, TestSSAValue, UnGraph, UnGraphExtra, UnGraphInfo, UniqueLiveSpecializationError,
+    Symbol, TestSSAValue, UnGraph, UnGraphExtra, UnGraphInfo, UniqueLiveSpecializationError, Use,
 };
 pub use pipeline::Pipeline;
 pub use product::{HasProduct, Product};

--- a/crates/kirin-ir/src/node/mod.rs
+++ b/crates/kirin-ir/src/node/mod.rs
@@ -22,7 +22,7 @@ pub use linked_list::{LinkedList, LinkedListNode};
 pub use port::{Port, PortParent};
 pub use ssa::{
     BlockArgument, BuilderKey, BuilderSSAInfo, BuilderSSAKind, DeletedSSAValue, ResolutionInfo,
-    ResultValue, SSAInfo, SSAKind, SSAValue, TestSSAValue,
+    ResultValue, SSAInfo, SSAKind, SSAValue, TestSSAValue, Use,
 };
 pub use stmt::{Statement, StatementInfo, StatementParent};
 pub use symbol::{GlobalSymbol, Symbol};

--- a/crates/kirin-ir/src/node/ssa.rs
+++ b/crates/kirin-ir/src/node/ssa.rs
@@ -3,6 +3,7 @@ use crate::identifier;
 use crate::{Dialect, Symbol};
 use smallvec::SmallVec;
 
+use super::digraph::DiGraph;
 use super::port::{Port, PortParent};
 use super::{block::Block, stmt::Statement};
 
@@ -238,10 +239,32 @@ impl<L: Dialect> From<SSAInfo<L>> for BuilderSSAInfo<L> {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Use {
-    stmt: Statement,
-    operand_index: usize,
+/// One def-use edge: a position in the IR that reads an SSA value.
+///
+/// Stored in [`SSAInfo::uses`] as the reverse index of the authoritative
+/// storage. Two kinds of position read a value:
+///
+/// - a **statement operand** slot (the usual case — `arith.add`'s operands,
+///   CFG branch arguments, `scf.yield` values, function returns), and
+/// - a **`DiGraph` body yield** — a value the graph exports across its body
+///   boundary. A yield has no backing statement (it lives in
+///   [`DiGraphInfo::yields`](crate::DiGraphInfo)), so it cannot be named as a
+///   statement operand, but it is a genuine use.
+///
+/// `UnGraph` has no analogue: its `Extra` is a list of edge *statements*, whose
+/// operands are already ordinary statement-operand uses.
+///
+/// Populated by
+/// [`StageInfo::rebuild_use_index`](crate::StageInfo::rebuild_use_index) at
+/// finalization; a mutation layer (the rewriter) must keep it in sync with
+/// every operand and yield change.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Use {
+    /// The `index`-th operand slot of `stmt`, in `HasArguments` order.
+    StatementOperand { stmt: Statement, index: usize },
+    /// The `index`-th yield slot of the directed graph body `graph`.
+    DiGraphYield { graph: DiGraph, index: usize },
 }
 
 /// A lookup key for builder placeholders — resolved at build time to the real SSA value.

--- a/crates/kirin-ir/src/stage/info.rs
+++ b/crates/kirin-ir/src/stage/info.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::arena::Arena;
-use crate::node::ssa::SSAInfo;
+use crate::arena::{Arena, Id};
+use crate::node::ssa::{SSAInfo, Use};
 use crate::{BuilderStageInfo, Dialect, node::*};
 
 use super::arenas::Arenas;
@@ -115,6 +115,68 @@ impl<L: Dialect> StageInfo<L> {
     /// deleted (tombstoned) items are `None`.
     pub fn ssa_arena(&self) -> &Arena<SSAValue, Option<SSAInfo<L>>> {
         &self.ssas
+    }
+
+    /// Rebuild the def-use index ([`SSAInfo::uses`](crate::SSAInfo)) from the
+    /// authoritative storage.
+    ///
+    /// Clears every live value's use list, then records one [`Use`](crate::Use)
+    /// per position that reads a value:
+    ///
+    /// - each live statement's operands (in [`HasArguments`](crate::HasArguments)
+    ///   order) → [`Use::StatementOperand`](crate::Use), and
+    /// - each live `DiGraph` body's yields (in yield order) →
+    ///   [`Use::DiGraphYield`](crate::Use). A yield is a boundary export with no
+    ///   backing statement, so it would otherwise be invisible to the operand
+    ///   scan.
+    ///
+    /// The operand and yield slots are the ground truth; this list is a derived
+    /// reverse index over them. `UnGraph` contributes nothing: its edges are
+    /// statements whose operands are already covered above; graph ports and
+    /// block arguments are definitions, not uses.
+    ///
+    /// Idempotent — safe to re-run. Called at
+    /// [`finalize`](crate::BuilderStageInfo::finalize) so finalized IR ships a
+    /// populated index; a mutation layer must call it (or maintain the index
+    /// incrementally) after changing operands or yields.
+    pub fn rebuild_use_index(&mut self) {
+        let StageInfo { nodes, ssas } = self;
+
+        for item in ssas.iter_mut() {
+            if let Some(info) = (**item).as_mut() {
+                info.uses_mut().clear();
+            }
+        }
+
+        for (raw, item) in nodes.statements.items.iter().enumerate() {
+            if item.deleted() {
+                continue;
+            }
+            let stmt = Statement(Id(raw));
+            let operands: Vec<SSAValue> = item.data.definition.arguments().copied().collect();
+            for (index, operand) in operands.into_iter().enumerate() {
+                if let Some(slot) = ssas.get_mut(operand)
+                    && let Some(info) = (**slot).as_mut()
+                {
+                    info.uses_mut().push(Use::StatementOperand { stmt, index });
+                }
+            }
+        }
+
+        for (raw, item) in nodes.digraphs.items.iter().enumerate() {
+            if item.deleted() {
+                continue;
+            }
+            let graph = DiGraph::from(Id(raw));
+            let yields: Vec<SSAValue> = item.data.yields().to_vec();
+            for (index, yielded) in yields.into_iter().enumerate() {
+                if let Some(slot) = ssas.get_mut(yielded)
+                    && let Some(info) = (**slot).as_mut()
+                {
+                    info.uses_mut().push(Use::DiGraphYield { graph, index });
+                }
+            }
+        }
     }
 
     /// Temporarily convert to a [`BuilderStageInfo`] for construction, then

--- a/crates/kirin-ir/tests/builder_block.rs
+++ b/crates/kirin-ir/tests/builder_block.rs
@@ -89,6 +89,58 @@ fn block_builder_substitutes_builder_block_arguments() {
 }
 
 #[test]
+fn finalize_populates_def_use_index() {
+    let mut stage = new_stage();
+
+    let arg0 = stage.block_argument().index(0);
+    let arg1 = stage.block_argument().index(1);
+
+    // arg0 is read twice (add operand 0, use operand 0); arg1 once (add operand 1).
+    let add_stmt = stage
+        .statement()
+        .definition(BuilderDialect::Add(arg0, arg1))
+        .new();
+    let use_stmt = stage
+        .statement()
+        .definition(BuilderDialect::Use(arg0))
+        .new();
+
+    let block = stage
+        .block()
+        .argument(TestType::I32)
+        .argument(TestType::I64)
+        .stmt(add_stmt)
+        .stmt(use_stmt)
+        .new();
+
+    let stage = stage.finalize().unwrap();
+    let block_info = block.expect_info(&stage);
+    let real_arg0: SSAValue = block_info.arguments[0].into();
+    let real_arg1: SSAValue = block_info.arguments[1].into();
+
+    let uses0 = real_arg0.get_info(&stage).unwrap().uses();
+    assert_eq!(uses0.len(), 2, "arg0 is read by two statements");
+    assert!(uses0.contains(&Use::StatementOperand {
+        stmt: add_stmt,
+        index: 0
+    }));
+    assert!(uses0.contains(&Use::StatementOperand {
+        stmt: use_stmt,
+        index: 0
+    }));
+
+    let uses1 = real_arg1.get_info(&stage).unwrap().uses();
+    assert_eq!(uses1.len(), 1, "arg1 is read only by the add");
+    assert_eq!(
+        uses1[0],
+        Use::StatementOperand {
+            stmt: add_stmt,
+            index: 1
+        }
+    );
+}
+
+#[test]
 #[should_panic(expected = "is not a terminator")]
 fn block_builder_terminator_rejects_non_terminator() {
     let mut stage = new_stage();

--- a/crates/kirin-ir/tests/builder_graph.rs
+++ b/crates/kirin-ir/tests/builder_graph.rs
@@ -35,6 +35,39 @@ fn digraph_builder_two_node_dag() {
 }
 
 #[test]
+fn finalize_indexes_digraph_yields_as_uses() {
+    let mut stage = new_stage();
+
+    // s0 produces %r; the graph yields %r. No statement reads %r, so its only
+    // use is the boundary yield — invisible to an operand-only scan.
+    let s0 = stage.statement().definition(BuilderDialect::Nop).new();
+    let result_ssa = stage
+        .ssa()
+        .ty(TestType::I32)
+        .kind(BuilderSSAKind::Result(s0, 0))
+        .new();
+
+    let dg = stage
+        .digraph()
+        .node(s0)
+        .yield_value(result_ssa)
+        .name("yielder")
+        .new();
+
+    let stage = stage.finalize().unwrap();
+
+    let uses = result_ssa.get_info(&stage).unwrap().uses();
+    assert_eq!(uses.len(), 1, "%r is used only by the graph yield");
+    assert_eq!(
+        uses[0],
+        Use::DiGraphYield {
+            graph: dg,
+            index: 0
+        }
+    );
+}
+
+#[test]
 fn digraph_builder_port_and_capture_creation() {
     let mut stage = new_stage();
 

--- a/crates/kirin-liveness/src/lib.rs
+++ b/crates/kirin-liveness/src/lib.rs
@@ -26,10 +26,11 @@ pub use live::{Live, LiveSet};
 pub use result::{DemandResult, DenseLivenessResult};
 
 use kirin_interpreter::{
-    Body, DenseBackwardInterpreter, DenseBackwardTransfer, InterpDispatch, InterpreterError,
+    Body, DenseBackwardCompletion, DenseBackwardDriver, DenseBackwardInterpreter,
+    DenseBackwardTransfer, DenseFrameBuild, Frame, InterpDispatch, InterpreterError,
     SparseBackwardDriver, SparseBackwardInterpreter, StageQuery, StandardDenseBackwardFrame,
 };
-use kirin_ir::{Cfg, CompileStage, Pipeline, StageMeta};
+use kirin_ir::{CompileStage, Pipeline, StageMeta};
 
 /// The sparse backward demand engine instantiated at the [`Live`] lattice:
 /// strong liveness.
@@ -59,9 +60,9 @@ where
 }
 
 /// Run classic per-point liveness (dense backward) over `body` in `stage`,
-/// with the standard (structured-control-free) frames. Languages with scf
-/// compose [`DenseLiveness`] with their own frame type and build the result
-/// via [`DenseLivenessResult::from_engine`].
+/// with the standard (structured-control-free) frames. Languages with
+/// structured dialects select their total frame through
+/// [`analyze_dense_with_frame`] instead.
 pub fn analyze_dense<'ir, S>(
     pipeline: &'ir Pipeline<S>,
     stage: CompileStage,
@@ -80,8 +81,32 @@ where
             >,
         >,
 {
+    analyze_dense_with_frame::<S, StandardDenseBackwardFrame<LiveSet, InterpreterError>>(
+        pipeline, stage, body,
+    )
+}
+
+/// Run classic per-point liveness (dense backward) over `body` in `stage`
+/// with a caller-selected total frame type `F` — the entry point for
+/// languages whose structured dialects require a language-specific total
+/// frame. The analysis consumes the finalized IR directly; it neither
+/// requires nor computes a demand ([`DemandResult`]) pre-pass.
+pub fn analyze_dense_with_frame<'ir, S, F>(
+    pipeline: &'ir Pipeline<S>,
+    stage: CompileStage,
+    body: impl Into<Body>,
+) -> Result<DenseLivenessResult, InterpreterError>
+where
+    S: StageMeta
+        + StageQuery
+        + InterpDispatch<DenseBackwardTransfer<'ir, S, LiveSet, InterpreterError, F>>,
+    F: Frame<
+            DenseBackwardDriver<'ir, S, LiveSet, InterpreterError, F>,
+            Completion = DenseBackwardCompletion<LiveSet>,
+        > + DenseFrameBuild<LiveSet, InterpreterError>,
+{
     let body = body.into();
-    let mut engine = DenseLiveness::<S>::new(pipeline);
+    let mut engine = DenseLiveness::<S, InterpreterError, F>::new(pipeline);
     engine.analyze(stage, body)?;
     DenseLivenessResult::from_engine(&mut engine, stage, body)
 }

--- a/crates/kirin-liveness/src/result.rs
+++ b/crates/kirin-liveness/src/result.rs
@@ -6,7 +6,7 @@ use kirin_interpreter::{
     DenseBackwardTransfer, DenseBlockStore, DenseFrameBuild, DensePointStore, Frame,
     InterpDispatch, InterpreterError, ProgramPoint, SparseBackwardInterpreter, StageQuery,
 };
-use kirin_ir::{Block, Cfg, CompileStage, Lattice, SSAValue, StageMeta, Statement};
+use kirin_ir::{Block, CompileStage, Lattice, SSAValue, StageMeta, Statement};
 
 use crate::live::{Live, LiveSet};
 

--- a/docs/design/interpreter/index.md
+++ b/docs/design/interpreter/index.md
@@ -563,7 +563,8 @@ and terminating on unknown inputs (both fold to `Top`). Runnable as
     kill/gen transfer (`gen_uses_kill_defs`, purity-irrelevant). Block owners
     converge boundary summaries; `live_before`/`live_after` are reconstructed
     per point on demand (never persisted by the fixpoint); scf owns dense
-    frames (arm-join, loop fixpoint).
+    frames (arm-join, loop fixpoint). Classic liveness consumes finalized IR
+    directly and does not require a sparse-demand pre-pass.
   Strong per-point sets are the composition `dense ∩ demanded`, not a third
   analysis. Because the `Semantics` parameter distinguishes impls, one dialect
   carries all three rules at once, as every shipped dialect demonstrates.

--- a/example/toy-lang/src/interpreter/mod.rs
+++ b/example/toy-lang/src/interpreter/mod.rs
@@ -22,7 +22,7 @@ use kirin_interpreter::engine::{
     CallContext, ConcreteInterpreter, CrossStageLinker, SameStageLinker, SparseForwardInterpreter,
     expect_single,
 };
-use kirin_liveness::{DemandResult, DenseLivenessResult, LiveSet};
+use kirin_liveness::{DenseLivenessResult, LiveSet};
 
 use crate::language::{HighLevel, LowLevel};
 use crate::stage::Stage;
@@ -45,18 +45,6 @@ pub type ToyConstProp<'ir, Lk = CrossStageLinker> = SparseForwardInterpreter<
     Lk,
     ConstPropContext,
     ToyAbstractFrame<ConstPropValue, ToyError, CpKey>,
->;
-
-/// Classic per-point liveness (dense backward) over toy programs, with a
-/// frame type embedding the SCF dense frames (arm join + loop fixpoint).
-/// Strong liveness needs no composition — the sparse demand engine has no
-/// frames (loop-carried demand converges on the value worklist), so
-/// [`kirin_liveness::analyze_demand`] applies directly.
-pub type ToyDenseLiveness<'ir> = kirin_liveness::DenseLiveness<
-    'ir,
-    Stage,
-    InterpreterError,
-    ToyDenseBackwardFrame<LiveSet, InterpreterError>,
 >;
 
 /// Execute `function_name` starting at `stage_name`, following calls across
@@ -188,18 +176,18 @@ fn function_cfg(
     Ok((stage_id, cfg))
 }
 
-/// Run both liveness analyses over `function_name`'s body at `stage_name`:
-/// strong liveness (the sparse demanded set — DCE-grade) and classic per-point
-/// liveness (dense block-boundary sets — regalloc-grade).
-pub fn analyze_liveness(
+/// Run classic per-point liveness (dense backward — regalloc-grade
+/// block-boundary and per-statement sets) over `function_name`'s body at
+/// `stage_name`. Consumes the finalized IR directly; strong demand
+/// ([`kirin_liveness::analyze_demand`]) is an independent analysis and is
+/// not involved.
+pub fn analyze_classic_liveness(
     pipeline: &Pipeline<Stage>,
     stage_name: &str,
     function_name: &str,
-) -> Result<(DemandResult, DenseLivenessResult), InterpreterError> {
+) -> Result<DenseLivenessResult, InterpreterError> {
     let (stage, cfg) = function_cfg(pipeline, stage_name, function_name)?;
-    let demand = kirin_liveness::analyze_demand(pipeline, stage, cfg)?;
-    let mut engine: ToyDenseLiveness<'_> = ToyDenseLiveness::new(pipeline);
-    engine.analyze(stage, cfg)?;
-    let dense = DenseLivenessResult::from_engine(&mut engine, stage, cfg)?;
-    Ok((demand, dense))
+    kirin_liveness::analyze_dense_with_frame::<_, ToyDenseBackwardFrame<LiveSet, InterpreterError>>(
+        pipeline, stage, cfg,
+    )
 }

--- a/example/toy-lang/src/interpreter/tests.rs
+++ b/example/toy-lang/src/interpreter/tests.rs
@@ -1255,32 +1255,35 @@ specialize @source fn @main(i64, i64) -> i64 {
 }
 
 // ===========================================================================
-// Classic (dense, per-point) liveness through scf's dialect-owned dense
-// frames: arm-join for `scf.if`, the loop-carried fixpoint for `scf.for`, and
-// per-point reconstruction inside structured bodies.
+// Classic (dense, per-point) liveness through the toy language's total dense
+// frame: arm-join for `scf.if`, the loop-carried fixpoint for `scf.for`, and
+// per-point reconstruction inside structured bodies. Runs on the finalized IR
+// alone — no demand pre-pass.
 // ===========================================================================
 
 mod dense {
     use kirin::prelude::{Cfg, CompileStage, Pipeline, SSAValue, Statement};
     use kirin_arith::{Arith, ArithValue};
-    use kirin_liveness::{DenseLivenessResult, LiveSet, analyze_demand};
+    use kirin_interpreter::InterpreterError;
+    use kirin_liveness::{DenseLivenessResult, LiveSet};
 
     use super::demand::{FOR_CARRIED_DEMAND, IF_DEAD_RESULT};
     use super::demand::{constant_result, entry_params, find_value, parse, source_cfg};
-    use crate::interpreter::ToyDenseLiveness;
+    use crate::interpreter::ToyDenseBackwardFrame;
     use crate::language::HighLevel;
     use crate::stage::Stage;
 
-    /// Run classic dense liveness with the toy total frame (scf frames
-    /// embedded).
+    /// Run classic dense liveness with the toy total frame.
     fn analyze_dense_toy(
         pipeline: &Pipeline<Stage>,
         stage: CompileStage,
         cfg: Cfg,
     ) -> DenseLivenessResult {
-        let mut engine: ToyDenseLiveness<'_> = ToyDenseLiveness::new(pipeline);
-        engine.analyze(stage, cfg).expect("analysis succeeds");
-        DenseLivenessResult::from_engine(&mut engine, stage, cfg).expect("reconstruction succeeds")
+        kirin_liveness::analyze_dense_with_frame::<
+            _,
+            ToyDenseBackwardFrame<LiveSet, InterpreterError>,
+        >(pipeline, stage, cfg)
+        .expect("analysis succeeds")
     }
 
     /// The statement whose definition matches `select` (anywhere in the
@@ -1309,15 +1312,15 @@ mod dense {
         values.iter().copied().collect()
     }
 
-    /// Per-point sets inside an `scf.if` arm follow classic semantics (the
-    /// yield's operand is live after its def even though the result is dead),
-    /// and intersecting with the demand set recovers the strong view.
+    /// Per-point sets inside an `scf.if` arm follow classic semantics: the
+    /// yield's operand is live after its def even though the result is dead.
+    /// (The strong view is the `dense ∩ demanded` composition, covered in
+    /// kirin-liveness — no demand pass runs here.)
     #[test]
     fn dense_per_point_inside_scf_if_arm() {
         let pipeline = parse(IF_DEAD_RESULT);
         let (stage, cfg) = source_cfg(&pipeline, "if_dead");
         let dense = analyze_dense_toy(&pipeline, stage, cfg);
-        let demand = analyze_demand(&pipeline, stage, cfg).expect("demand succeeds");
 
         let cond = entry_params(&pipeline, cfg)[0];
         let a = constant_result(&pipeline, cfg, 1);
@@ -1331,20 +1334,55 @@ mod dense {
         assert_eq!(dense.live_after(a_const), Some(&live_set(&[cond, a])));
         assert_eq!(dense.live_before(a_const), Some(&live_set(&[cond])));
 
-        // The if's own points: its dead result is live after it (classic
-        // records what the walk saw: nothing uses it, so it is NOT live), and
-        // before it only the condition survives the arm join.
+        // The if's dead result is not live after it because nothing uses it;
+        // before it, only the condition survives the arm join.
         let if_stmt = find_statement(&pipeline, cfg, |definition| {
             matches!(definition, HighLevel::Structured(_))
         });
         assert_eq!(dense.live_before(if_stmt), Some(&live_set(&[cond])));
+    }
 
-        // Strong per-point view: %a is classically live after its def but not
-        // demanded (the if result is dead), so the composition drops it.
-        let strong = dense
-            .strong_live_after(a_const, &demand)
-            .expect("point reconstructed");
-        assert_eq!(strong, live_set(&[cond]));
+    const IF_ARMS_DIFFERENT_USES: &str = r#"
+stage @source fn @if_arms(i64, i64, i64) -> i64;
+
+specialize @source fn @if_arms(i64, i64, i64) -> i64 {
+  ^entry(%cond: i64, %x: i64, %y: i64) {
+    %r = if %cond then ^then() {
+      yield %x;
+    } else ^else() {
+      yield %y;
+    } -> i64;
+    ret %r;
+  }
+}
+"#;
+
+    /// The scf.if liveness frame walks BOTH arms backward and joins their
+    /// live-entry states: the arms use different SSA values (%x vs %y), so
+    /// the state before the `if` must contain the condition and both.
+    #[test]
+    fn dense_scf_if_joins_both_arm_entries() {
+        let pipeline = parse(IF_ARMS_DIFFERENT_USES);
+        let (stage, cfg) = source_cfg(&pipeline, "if_arms");
+        let dense = analyze_dense_toy(&pipeline, stage, cfg);
+
+        let params = entry_params(&pipeline, cfg);
+        let (cond, x, y) = (params[0], params[1], params[2]);
+        let if_stmt = find_statement(&pipeline, cfg, |definition| {
+            matches!(definition, HighLevel::Structured(_))
+        });
+        let r = find_value(&pipeline, cfg, |definition| match definition {
+            HighLevel::Structured(_) => {
+                use kirin::prelude::HasResults;
+                definition.results().next().map(|v| SSAValue::from(*v))
+            }
+            _ => None,
+        });
+
+        // After the if only its result matters; before it, the then-arm
+        // contributed %x, the else-arm %y, and the rule genned %cond.
+        assert_eq!(dense.live_after(if_stmt), Some(&live_set(&[r])));
+        assert_eq!(dense.live_before(if_stmt), Some(&live_set(&[cond, x, y])));
     }
 
     /// The scf.for dense frame iterates the body walk to the loop-carried

--- a/example/toy-lang/src/main.rs
+++ b/example/toy-lang/src/main.rs
@@ -41,8 +41,8 @@ enum Command {
         /// Run constant propagation instead of concrete execution.
         #[arg(long)]
         constprop: bool,
-        /// Run liveness analysis (strong demand + classic per-point) instead
-        /// of concrete execution.
+        /// Run classic per-program-point liveness analysis (dense backward)
+        /// instead of concrete execution.
         #[arg(long)]
         liveness: bool,
         /// Restrict execution to the entry stage's language; reject calls
@@ -108,8 +108,7 @@ fn run_program(
     }
 
     if liveness {
-        let (demand, dense) = interpreter::analyze_liveness(&pipeline, stage_name, func_name)?;
-        println!("demanded: {:?}", demand.demanded());
+        let dense = interpreter::analyze_classic_liveness(&pipeline, stage_name, func_name)?;
         let mut boundaries: Vec<_> = dense
             .blocks()
             .map(|(block, live_in, live_out)| format!("{block:?}: in={live_in:?} out={live_out:?}"))

--- a/example/toy-lang/tests/e2e.rs
+++ b/example/toy-lang/tests/e2e.rs
@@ -177,3 +177,28 @@ fn test_run_missing_stage() {
         .assert()
         .failure();
 }
+
+#[test]
+fn test_liveness_prints_dense_sets_without_demand() {
+    // `--liveness` runs exactly one analysis: classic dense-backward
+    // per-point liveness. It prints block boundary sets and must NOT run or
+    // print the independent strong-demand analysis.
+    toy_lang()
+        .args([
+            "run",
+            "programs/branching.kirin",
+            "--stage",
+            "source",
+            "--function",
+            "abs",
+            "--liveness",
+        ])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("in=")
+                .and(predicate::str::contains("out="))
+                .and(predicate::str::contains("demanded:").not()),
+        );
+}


### PR DESCRIPTION
Addresses the remaining liveness concern from #667.

- Rename analyze_liveness to analyze_classic_liveness.
- Make --liveness run only dense ClassicLiveness.
- Remove the unnecessary sparse-demand pre-pass and demanded: output.