### PR TITLE
Fixed SSAInfo.uses def-use population at finalize.

### DIFF
--- a/crates/kirin-ir/src/builder/stage_info.rs
+++ b/crates/kirin-ir/src/builder/stage_info.rs
@@ -236,10 +236,12 @@ impl<L: Dialect> BuilderStageInfo<L> {
             },
             |_info| None,
         );
-        Ok(StageInfo {
+        let mut stage = StageInfo {
             nodes: self.nodes,
             ssas,
-        })
+        };
+        stage.rebuild_use_index();
+        Ok(stage)
     }
 
     /// Convert to [`StageInfo`] without validation.
@@ -279,10 +281,12 @@ impl<L: Dialect> BuilderStageInfo<L> {
             // Deleted items become None tombstones — safe, no zeroed memory.
             |_info| None,
         );
-        StageInfo {
+        let mut stage = StageInfo {
             nodes: self.nodes,
             ssas,
-        }
+        };
+        stage.rebuild_use_index();
+        stage
     }
 }
 

--- a/crates/kirin-ir/src/lib.rs
+++ b/crates/kirin-ir/src/lib.rs
@@ -37,7 +37,7 @@ pub use node::{
     GraphInfo, LinkedList, LinkedListNode, Port, PortParent, ResolutionInfo, ResultValue, SSAInfo,
     SSAKind, SSAValue, SpecializedFunction, SpecializedFunctionInfo, StagedFunction,
     StagedFunctionInfo, StagedNamePolicy, Statement, StatementInfo, StatementParent, Successor,
-    Symbol, TestSSAValue, UnGraph, UnGraphExtra, UnGraphInfo, UniqueLiveSpecializationError,
+    Symbol, TestSSAValue, UnGraph, UnGraphExtra, UnGraphInfo, UniqueLiveSpecializationError, Use,
 };
 pub use pipeline::Pipeline;
 pub use product::{HasProduct, Product};

--- a/crates/kirin-ir/src/node/mod.rs
+++ b/crates/kirin-ir/src/node/mod.rs
@@ -22,7 +22,7 @@ pub use linked_list::{LinkedList, LinkedListNode};
 pub use port::{Port, PortParent};
 pub use ssa::{
     BlockArgument, BuilderKey, BuilderSSAInfo, BuilderSSAKind, DeletedSSAValue, ResolutionInfo,
-    ResultValue, SSAInfo, SSAKind, SSAValue, TestSSAValue,
+    ResultValue, SSAInfo, SSAKind, SSAValue, TestSSAValue, Use,
 };
 pub use stmt::{Statement, StatementInfo, StatementParent};
 pub use symbol::{GlobalSymbol, Symbol};

--- a/crates/kirin-ir/src/node/ssa.rs
+++ b/crates/kirin-ir/src/node/ssa.rs
@@ -238,10 +238,38 @@ impl<L: Dialect> From<SSAInfo<L>> for BuilderSSAInfo<L> {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+/// One def-use edge: an operand slot of `stmt` that reads an SSA value.
+///
+/// Stored in [`SSAInfo::uses`] as the reverse index of the authoritative
+/// operand storage inside each statement's dialect definition. Populated by
+/// [`StageInfo::rebuild_use_index`](crate::StageInfo::rebuild_use_index) at
+/// finalization; a mutation layer (the rewriter) must keep it in sync with
+/// every operand change.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Use {
     stmt: Statement,
     operand_index: usize,
+}
+
+impl Use {
+    /// A use at operand slot `operand_index` (in `HasArguments` order) of `stmt`.
+    pub fn new(stmt: Statement, operand_index: usize) -> Self {
+        Self {
+            stmt,
+            operand_index,
+        }
+    }
+
+    /// The statement whose operand slot reads the value.
+    pub fn stmt(&self) -> Statement {
+        self.stmt
+    }
+
+    /// The operand index within the statement, in `HasArguments` order.
+    pub fn operand_index(&self) -> usize {
+        self.operand_index
+    }
 }
 
 /// A lookup key for builder placeholders — resolved at build time to the real SSA value.

--- a/crates/kirin-ir/src/node/ssa.rs
+++ b/crates/kirin-ir/src/node/ssa.rs
@@ -3,6 +3,7 @@ use crate::identifier;
 use crate::{Dialect, Symbol};
 use smallvec::SmallVec;
 
+use super::digraph::DiGraph;
 use super::port::{Port, PortParent};
 use super::{block::Block, stmt::Statement};
 
@@ -238,38 +239,32 @@ impl<L: Dialect> From<SSAInfo<L>> for BuilderSSAInfo<L> {
     }
 }
 
-/// One def-use edge: an operand slot of `stmt` that reads an SSA value.
+/// One def-use edge: a position in the IR that reads an SSA value.
 ///
 /// Stored in [`SSAInfo::uses`] as the reverse index of the authoritative
-/// operand storage inside each statement's dialect definition. Populated by
+/// storage. Two kinds of position read a value:
+///
+/// - a **statement operand** slot (the usual case — `arith.add`'s operands,
+///   CFG branch arguments, `scf.yield` values, function returns), and
+/// - a **`DiGraph` body yield** — a value the graph exports across its body
+///   boundary. A yield has no backing statement (it lives in
+///   [`DiGraphInfo::yields`](crate::DiGraphInfo)), so it cannot be named as a
+///   statement operand, but it is a genuine use.
+///
+/// `UnGraph` has no analogue: its `Extra` is a list of edge *statements*, whose
+/// operands are already ordinary statement-operand uses.
+///
+/// Populated by
 /// [`StageInfo::rebuild_use_index`](crate::StageInfo::rebuild_use_index) at
 /// finalization; a mutation layer (the rewriter) must keep it in sync with
-/// every operand change.
+/// every operand and yield change.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Use {
-    stmt: Statement,
-    operand_index: usize,
-}
-
-impl Use {
-    /// A use at operand slot `operand_index` (in `HasArguments` order) of `stmt`.
-    pub fn new(stmt: Statement, operand_index: usize) -> Self {
-        Self {
-            stmt,
-            operand_index,
-        }
-    }
-
-    /// The statement whose operand slot reads the value.
-    pub fn stmt(&self) -> Statement {
-        self.stmt
-    }
-
-    /// The operand index within the statement, in `HasArguments` order.
-    pub fn operand_index(&self) -> usize {
-        self.operand_index
-    }
+pub enum Use {
+    /// The `index`-th operand slot of `stmt`, in `HasArguments` order.
+    StatementOperand { stmt: Statement, index: usize },
+    /// The `index`-th yield slot of the directed graph body `graph`.
+    DiGraphYield { graph: DiGraph, index: usize },
 }
 
 /// A lookup key for builder placeholders — resolved at build time to the real SSA value.

--- a/crates/kirin-ir/src/stage/info.rs
+++ b/crates/kirin-ir/src/stage/info.rs
@@ -118,22 +118,27 @@ impl<L: Dialect> StageInfo<L> {
     }
 
     /// Rebuild the def-use index ([`SSAInfo::uses`](crate::SSAInfo)) from the
-    /// authoritative operand storage.
+    /// authoritative storage.
     ///
-    /// Clears every live value's use list, then scans each live statement's
-    /// operands (in [`HasArguments`](crate::HasArguments) order) and records
-    /// one [`Use`](crate::Use) per operand slot on the value it reads. The
-    /// statement operand slots are the ground truth; this list is a derived
-    /// reverse index over them.
+    /// Clears every live value's use list, then records one [`Use`](crate::Use)
+    /// per position that reads a value:
+    ///
+    /// - each live statement's operands (in [`HasArguments`](crate::HasArguments)
+    ///   order) → [`Use::StatementOperand`](crate::Use), and
+    /// - each live `DiGraph` body's yields (in yield order) →
+    ///   [`Use::DiGraphYield`](crate::Use). A yield is a boundary export with no
+    ///   backing statement, so it would otherwise be invisible to the operand
+    ///   scan.
+    ///
+    /// The operand and yield slots are the ground truth; this list is a derived
+    /// reverse index over them. `UnGraph` contributes nothing: its edges are
+    /// statements whose operands are already covered above; graph ports and
+    /// block arguments are definitions, not uses.
     ///
     /// Idempotent — safe to re-run. Called at
     /// [`finalize`](crate::BuilderStageInfo::finalize) so finalized IR ships a
     /// populated index; a mutation layer must call it (or maintain the index
-    /// incrementally) after changing operands.
-    ///
-    /// Only statement operands are indexed. SSA slots stored on graph bodies
-    /// (`DiGraph` yields, edge/capture ports) are not yet represented by
-    /// [`Use`](crate::Use) and are excluded.
+    /// incrementally) after changing operands or yields.
     pub fn rebuild_use_index(&mut self) {
         let StageInfo { nodes, ssas } = self;
 
@@ -143,17 +148,32 @@ impl<L: Dialect> StageInfo<L> {
             }
         }
 
-        for (index, item) in nodes.statements.items.iter().enumerate() {
+        for (raw, item) in nodes.statements.items.iter().enumerate() {
             if item.deleted() {
                 continue;
             }
-            let stmt = Statement(Id(index));
+            let stmt = Statement(Id(raw));
             let operands: Vec<SSAValue> = item.data.definition.arguments().copied().collect();
-            for (operand_index, operand) in operands.into_iter().enumerate() {
+            for (index, operand) in operands.into_iter().enumerate() {
                 if let Some(slot) = ssas.get_mut(operand)
                     && let Some(info) = (**slot).as_mut()
                 {
-                    info.uses_mut().push(Use::new(stmt, operand_index));
+                    info.uses_mut().push(Use::StatementOperand { stmt, index });
+                }
+            }
+        }
+
+        for (raw, item) in nodes.digraphs.items.iter().enumerate() {
+            if item.deleted() {
+                continue;
+            }
+            let graph = DiGraph::from(Id(raw));
+            let yields: Vec<SSAValue> = item.data.yields().to_vec();
+            for (index, yielded) in yields.into_iter().enumerate() {
+                if let Some(slot) = ssas.get_mut(yielded)
+                    && let Some(info) = (**slot).as_mut()
+                {
+                    info.uses_mut().push(Use::DiGraphYield { graph, index });
                 }
             }
         }

--- a/crates/kirin-ir/src/stage/info.rs
+++ b/crates/kirin-ir/src/stage/info.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::arena::Arena;
-use crate::node::ssa::SSAInfo;
+use crate::arena::{Arena, Id};
+use crate::node::ssa::{SSAInfo, Use};
 use crate::{BuilderStageInfo, Dialect, node::*};
 
 use super::arenas::Arenas;
@@ -115,6 +115,48 @@ impl<L: Dialect> StageInfo<L> {
     /// deleted (tombstoned) items are `None`.
     pub fn ssa_arena(&self) -> &Arena<SSAValue, Option<SSAInfo<L>>> {
         &self.ssas
+    }
+
+    /// Rebuild the def-use index ([`SSAInfo::uses`](crate::SSAInfo)) from the
+    /// authoritative operand storage.
+    ///
+    /// Clears every live value's use list, then scans each live statement's
+    /// operands (in [`HasArguments`](crate::HasArguments) order) and records
+    /// one [`Use`](crate::Use) per operand slot on the value it reads. The
+    /// statement operand slots are the ground truth; this list is a derived
+    /// reverse index over them.
+    ///
+    /// Idempotent — safe to re-run. Called at
+    /// [`finalize`](crate::BuilderStageInfo::finalize) so finalized IR ships a
+    /// populated index; a mutation layer must call it (or maintain the index
+    /// incrementally) after changing operands.
+    ///
+    /// Only statement operands are indexed. SSA slots stored on graph bodies
+    /// (`DiGraph` yields, edge/capture ports) are not yet represented by
+    /// [`Use`](crate::Use) and are excluded.
+    pub fn rebuild_use_index(&mut self) {
+        let StageInfo { nodes, ssas } = self;
+
+        for item in ssas.iter_mut() {
+            if let Some(info) = (**item).as_mut() {
+                info.uses_mut().clear();
+            }
+        }
+
+        for (index, item) in nodes.statements.items.iter().enumerate() {
+            if item.deleted() {
+                continue;
+            }
+            let stmt = Statement(Id(index));
+            let operands: Vec<SSAValue> = item.data.definition.arguments().copied().collect();
+            for (operand_index, operand) in operands.into_iter().enumerate() {
+                if let Some(slot) = ssas.get_mut(operand)
+                    && let Some(info) = (**slot).as_mut()
+                {
+                    info.uses_mut().push(Use::new(stmt, operand_index));
+                }
+            }
+        }
     }
 
     /// Temporarily convert to a [`BuilderStageInfo`] for construction, then

--- a/crates/kirin-ir/tests/builder_block.rs
+++ b/crates/kirin-ir/tests/builder_block.rs
@@ -89,6 +89,55 @@ fn block_builder_substitutes_builder_block_arguments() {
 }
 
 #[test]
+fn finalize_populates_def_use_index() {
+    let mut stage = new_stage();
+
+    let arg0 = stage.block_argument().index(0);
+    let arg1 = stage.block_argument().index(1);
+
+    // arg0 is read twice (add operand 0, use operand 0); arg1 once (add operand 1).
+    let add_stmt = stage
+        .statement()
+        .definition(BuilderDialect::Add(arg0, arg1))
+        .new();
+    let use_stmt = stage
+        .statement()
+        .definition(BuilderDialect::Use(arg0))
+        .new();
+
+    let block = stage
+        .block()
+        .argument(TestType::I32)
+        .argument(TestType::I64)
+        .stmt(add_stmt)
+        .stmt(use_stmt)
+        .new();
+
+    let stage = stage.finalize().unwrap();
+    let block_info = block.expect_info(&stage);
+    let real_arg0: SSAValue = block_info.arguments[0].into();
+    let real_arg1: SSAValue = block_info.arguments[1].into();
+
+    let uses0 = real_arg0.get_info(&stage).unwrap().uses();
+    assert_eq!(uses0.len(), 2, "arg0 is read by two statements");
+    assert!(
+        uses0
+            .iter()
+            .any(|u| u.stmt() == add_stmt && u.operand_index() == 0)
+    );
+    assert!(
+        uses0
+            .iter()
+            .any(|u| u.stmt() == use_stmt && u.operand_index() == 0)
+    );
+
+    let uses1 = real_arg1.get_info(&stage).unwrap().uses();
+    assert_eq!(uses1.len(), 1, "arg1 is read only by the add");
+    assert_eq!(uses1[0].stmt(), add_stmt);
+    assert_eq!(uses1[0].operand_index(), 1);
+}
+
+#[test]
 #[should_panic(expected = "is not a terminator")]
 fn block_builder_terminator_rejects_non_terminator() {
     let mut stage = new_stage();

--- a/crates/kirin-ir/tests/builder_block.rs
+++ b/crates/kirin-ir/tests/builder_block.rs
@@ -120,21 +120,24 @@ fn finalize_populates_def_use_index() {
 
     let uses0 = real_arg0.get_info(&stage).unwrap().uses();
     assert_eq!(uses0.len(), 2, "arg0 is read by two statements");
-    assert!(
-        uses0
-            .iter()
-            .any(|u| u.stmt() == add_stmt && u.operand_index() == 0)
-    );
-    assert!(
-        uses0
-            .iter()
-            .any(|u| u.stmt() == use_stmt && u.operand_index() == 0)
-    );
+    assert!(uses0.contains(&Use::StatementOperand {
+        stmt: add_stmt,
+        index: 0
+    }));
+    assert!(uses0.contains(&Use::StatementOperand {
+        stmt: use_stmt,
+        index: 0
+    }));
 
     let uses1 = real_arg1.get_info(&stage).unwrap().uses();
     assert_eq!(uses1.len(), 1, "arg1 is read only by the add");
-    assert_eq!(uses1[0].stmt(), add_stmt);
-    assert_eq!(uses1[0].operand_index(), 1);
+    assert_eq!(
+        uses1[0],
+        Use::StatementOperand {
+            stmt: add_stmt,
+            index: 1
+        }
+    );
 }
 
 #[test]

--- a/crates/kirin-ir/tests/builder_graph.rs
+++ b/crates/kirin-ir/tests/builder_graph.rs
@@ -35,6 +35,39 @@ fn digraph_builder_two_node_dag() {
 }
 
 #[test]
+fn finalize_indexes_digraph_yields_as_uses() {
+    let mut stage = new_stage();
+
+    // s0 produces %r; the graph yields %r. No statement reads %r, so its only
+    // use is the boundary yield — invisible to an operand-only scan.
+    let s0 = stage.statement().definition(BuilderDialect::Nop).new();
+    let result_ssa = stage
+        .ssa()
+        .ty(TestType::I32)
+        .kind(BuilderSSAKind::Result(s0, 0))
+        .new();
+
+    let dg = stage
+        .digraph()
+        .node(s0)
+        .yield_value(result_ssa)
+        .name("yielder")
+        .new();
+
+    let stage = stage.finalize().unwrap();
+
+    let uses = result_ssa.get_info(&stage).unwrap().uses();
+    assert_eq!(uses.len(), 1, "%r is used only by the graph yield");
+    assert_eq!(
+        uses[0],
+        Use::DiGraphYield {
+            graph: dg,
+            index: 0
+        }
+    );
+}
+
+#[test]
 fn digraph_builder_port_and_capture_creation() {
     let mut stage = new_stage();
 


### PR DESCRIPTION
Builders set `SSAInfo.kind` (use→def) but nobody ever populated `SSAInfo.uses` (def→use). Both finalize paths just copied an always-empty vec through. So finalized IR shipped an empty def-use.

- `StageInfo::rebuild_use_index()`: clears every live value's `uses,` then scans each live statement's operands (`HasArguments` order) and records one `Use { stmt, operand_index } `on the value each slot reads. Idempotent, so the future rewriter can re-run it. Skips deleted statements/tombstoned SSAs.
- both `finalize()` and `finalize_unchecked()` call it before returning.
- `Use` gains `new()` + `stmt()/operand_index()` accessors, `Copy`, and serde parity with its container `SSAInfo`.
- `rebuild_use_index` now scan over nodes.digraphs, pushing a `DiGraphYield { graph, index }` into `SSAInfo.uses`.


```rust
pub enum Use {
    StatementOperand { stmt: Statement, index: usize },
    DiGraphYield     { graph: DiGraph,  index: usize },
}
```
