### PR TITLE
Backport #693 to release-0-22

### DIFF
--- a/docs/adr/0001-ssacfg-dependency-triggered-reevaluation.md
+++ b/docs/adr/0001-ssacfg-dependency-triggered-reevaluation.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+---
+
+# Reevaluate SSACFG blocks through abstract-value dependencies
+
+Kirin's generic SSACFG abstract interpreter will revisit a reached block when
+an abstract SSA value on which that block depends changes. This preserves
+soundness for ordinary SSA uses of values from dominating blocks, including
+uses inside nested regions. Dependencies are discovered from the IR's static
+SSA use-def graph, with nested uses attributed to their enclosing SSACFG block;
+transfer functions must not hide SSA dependencies from the IR. A separate
+liveness analysis should be introduced only when a consumer needs live-in or
+live-out queries, because using liveness snapshots as worklist keys would couple
+the forward solver to an otherwise unnecessary backward analysis. The existing
+successor worklist and its path-sensitive edge arguments remain intact;
+dependency invalidation extends that mechanism instead of replacing it with a
+new block-state solver. Dependency changes requeue only blocks already proven
+reachable by normal CFG traversal, with reachability tracked separately from
+the visited-state cache so unreachable code is not analyzed speculatively.
+Each reached block has a dependency generation that advances when one of its
+abstract SSA dependencies changes; the generation is part of visitation
+identity, preserving deduplication without deleting visit history. The existing
+limit of 128 visited states per block and its silent truncation behavior remain
+unchanged.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,11 @@
+# Domain docs
+
+This repository uses a single-context domain-documentation layout.
+
+Before exploring an area, read the root `CONTEXT.md` when it exists and the
+relevant records under `docs/adr/`. Their vocabulary and decisions take
+precedence over informal synonyms or assumptions.
+
+Missing domain files are not errors. Create glossary entries or ADRs lazily
+through the domain-modeling workflow when terminology or durable decisions are
+actually resolved.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,18 @@
+# Issue tracker: Local Markdown
+
+Issues and specs for this repository live as Markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The spec is `.scratch/<feature-slug>/spec.md`
+- Implementation issues are individual files under
+  `.scratch/<feature-slug>/issues/`, numbered from `01`
+- A `Status:` line near the top records triage state
+- Comments append under a `## Comments` heading
+
+## Publishing and fetching
+
+When a skill publishes a spec or issue, it creates the corresponding Markdown
+file under `.scratch/`. When a skill fetches a ticket, it reads the referenced
+file directly.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,9 @@
+# Triage labels
+
+| Canonical role | Local status | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer evaluation is required |
+| `needs-info` | `needs-info` | More reporter information is required |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and ready for implementation |
+| `ready-for-human` | `ready-for-human` | Human implementation is required |
+| `wontfix` | `wontfix` | The request will not be implemented |

--- a/src/kirin/analysis/forward.py
+++ b/src/kirin/analysis/forward.py
@@ -17,9 +17,9 @@ class ForwardFrame(interp.AbstractFrame[LatticeType]):
     ) -> None:
         for ssa_value, result in zip(keys, values):
             if ssa_value in self.entries:
-                self.entries[ssa_value] = self.entries[ssa_value].join(result)
+                self.set(ssa_value, self.entries[ssa_value].join(result))
             else:
-                self.entries[ssa_value] = result
+                self.set(ssa_value, result)
 
 
 FrameType = TypeVar("FrameType", bound=ForwardFrame)

--- a/src/kirin/dialects/ssacfg.py
+++ b/src/kirin/dialects/ssacfg.py
@@ -36,6 +36,35 @@ class Concrete(interp.MethodTable):
 
 @dialect.register(key="abstract")
 class Abstract(interp.MethodTable):
+    """Evaluate an SSACFG region with a dependency-aware worklist.
+
+    The worklist contains path-sensitive :class:`Successor` values: a destination
+    block paired with the abstract values passed to its block arguments. Each
+    popped successor is checked against this visitation key::
+
+        (successor, generations[successor.block])
+
+    The generation is a per-block invalidation counter. Suppose ``^2`` has
+    already been evaluated through ``Successor(^2, True)``. If an SSA value read
+    by ``^2`` changes, the solver increments ``generations[^2]`` and requeues the
+    same successor. Although its explicit block arguments have not changed, the
+    new generation gives it a distinct visitation key::
+
+        (Successor(^2, True), 0)  # original evaluation
+        (Successor(^2, True), 1)  # reevaluation after invalidation
+
+    Dependencies come from a static SSA use-def map, with nested uses attributed
+    to their enclosing SSACFG block. A dependency change only requeues blocks
+    already reached through normal control flow.
+
+    The generation is read when work is popped; it is not stored in the queued
+    successor. If several invalidations are pending for one block, every queued
+    copy therefore observes the latest generation. The first copy is evaluated
+    and the remaining copies match its visitation key and are skipped.
+
+    Unreached blocks are never scheduled by dependency changes, and the existing
+    per-block visitation limit remains the convergence guard.
+    """
 
     FrameType = TypeVar("FrameType", bound=interp.AbstractFrame)
     LatticeType = TypeVar("LatticeType", bound=lattice.BoundedLattice)
@@ -48,19 +77,43 @@ class Abstract(interp.MethodTable):
         node: ir.Region,
     ):
         result = None
+        dependents: dict[ir.SSAValue, set[ir.Block]] = {}
+        reached: set[ir.Block] = set()
+        generations: dict[ir.Block, int] = {}
         frame.worklist.append(
             interp.Successor(node.blocks[0], *frame.get_values(node.blocks[0].args))
         )
         while (succ := frame.worklist.pop()) is not None:
             visited = frame.visited.setdefault(succ.block, set())
-            if succ in visited:
+            generation = generations.get(succ.block, 0)
+            visit = (succ, generation)
+            if visit in visited:
                 continue
 
-            block_result = self.run_succ(interp_, frame, succ)
+            reached.add(succ.block)
+            block_result, changes = self.run_succ(interp_, frame, succ)
             if len(frame.visited[succ.block]) < 128:
-                frame.visited[succ.block].add(succ)
+                frame.visited[succ.block].add(visit)
             else:
                 continue
+
+            for value in changes:
+                blocks = dependents.get(value)
+                if blocks is None:
+                    blocks = set()
+                    dependents[value] = blocks
+                    for use in value.uses:
+                        block = self._get_enclosing_block(node, use.stmt)
+                        if block is not None:
+                            blocks.add(block)
+
+                for block in blocks:
+                    if block is succ.block or block not in reached:
+                        continue
+                    generations[block] = generations.get(block, 0) + 1
+                    frame.worklist.append(
+                        interp.Successor(block, *frame.get_values(block.args))
+                    )
 
             if isinstance(block_result, interp.Successor):
                 raise interp.InterpreterError(
@@ -73,12 +126,23 @@ class Abstract(interp.MethodTable):
             return result.values
         return result
 
+    @staticmethod
+    def _get_enclosing_block(region: ir.Region, stmt: ir.Statement) -> ir.Block | None:
+        node: ir.IRNode | None = stmt
+        while node is not None:
+            parent = node.parent_node
+            if isinstance(parent, ir.Block) and parent.parent_node is region:
+                return parent
+            node = parent
+        return None
+
     def run_succ(
         self,
         interp_: interp.AbstractInterpreter[FrameType, LatticeType],
         frame: FrameType,
         succ: interp.Successor,
-    ) -> interp.SpecialValue[LatticeType]:
+    ) -> tuple[interp.SpecialValue[LatticeType], set[ir.SSAValue]]:
+        frame._take_changes()
         frame.current_block = succ.block
         frame.set_values(succ.block.args, succ.block_args)
         for stmt in succ.block.stmts:
@@ -89,5 +153,5 @@ class Abstract(interp.MethodTable):
             elif stmt_results is None:
                 continue  # empty result
             else:  # terminate
-                return stmt_results
-        return None
+                return stmt_results, frame._take_changes()
+        return None, frame._take_changes()

--- a/src/kirin/interp/abstract.py
+++ b/src/kirin/interp/abstract.py
@@ -22,14 +22,41 @@ AbsIntResultType: TypeAlias = (
 
 @dataclass
 class AbstractFrame(Frame[ResultType]):
-    """Interpreter frame for abstract interpreter.
+    """Store abstract SSA values and worklist state for an analysis call.
 
-    This frame is used to store the state of the abstract interpreter.
-    It contains the worklist of successors to be processed.
+    In addition to the SSA-value entries inherited from :class:`Frame`, an
+    abstract frame owns the pending control-flow successors and the visitation
+    identities already evaluated for each block. A visitation identity combines
+    a path-sensitive successor with the dependency generation maintained by the
+    SSACFG solver. This lets an unchanged control-flow edge run again after an
+    SSA value used by its destination changes.
+
+    Assignments record values whose lattice meaning changed in ``_changes``.
+    The SSACFG solver drains that set after evaluating a block and requeues any
+    reached blocks that depend on those values. Multiple pending invalidations
+    at the same latest generation therefore share one visitation identity.
     """
 
     worklist: WorkList[Successor[ResultType]] = field(default_factory=WorkList)
-    visited: dict[ir.Block, set[Successor[ResultType]]] = field(default_factory=dict)
+    visited: dict[ir.Block, set[tuple[Successor[ResultType], int]]] = field(
+        default_factory=dict
+    )
+    _changes: set[ir.SSAValue] = field(
+        default_factory=set, init=False, compare=False, repr=False
+    )
+
+    def set(self, key: ir.SSAValue, value: ResultType) -> None:
+        previous = self.entries.get(key)
+        self.entries[key] = value
+        if previous is None or not (
+            previous.is_subseteq(value) and value.is_subseteq(previous)
+        ):
+            self._changes.add(key)
+
+    def _take_changes(self) -> set[ir.SSAValue]:
+        changes = self._changes
+        self._changes = set()
+        return changes
 
 
 AbstractFrameType = TypeVar("AbstractFrameType", bound=AbstractFrame)

--- a/test/analysis/dataflow/constprop/test_constprop.py
+++ b/test/analysis/dataflow/constprop/test_constprop.py
@@ -1,8 +1,54 @@
-from kirin import ir, types, lowering
+from kirin import ir, types, interp, lowering
 from kirin.decl import info, statement
-from kirin.prelude import basic_no_opt
+from kirin.prelude import basic_no_opt, structural_no_opt
+from kirin.rewrite import Walk, Inline
 from kirin.analysis import const
-from kirin.dialects import ilist
+from kirin.dialects import py, scf, ilist
+from kirin.passes.fold import Fold
+
+nested_dialect = ir.Dialect("nested")
+
+
+@statement(dialect=nested_dialect, init=False)
+class NestedYield(ir.Statement):
+    name = "yield"
+    traits = frozenset({ir.IsTerminator()})
+    values: tuple[ir.SSAValue, ...] = info.argument(types.Any)
+
+    def __init__(self, *values: ir.SSAValue):
+        super().__init__(args=values, args_slice={"values": slice(None)})
+
+
+@statement(dialect=nested_dialect, init=False)
+class NestedRegion(ir.Statement):
+    name = "region"
+    traits = frozenset({ir.Pure(), ir.SSACFG(), lowering.FromPythonCall()})
+    body: ir.Region = info.region(multi=False)
+
+    def __init__(self, body: ir.Region):
+        terminator = body.blocks[0].last_stmt
+        assert isinstance(terminator, NestedYield)
+        super().__init__(
+            regions=(body,),
+            result_types=tuple(value.type for value in terminator.values),
+        )
+
+
+@nested_dialect.register(key="constprop")
+class NestedConstProp(interp.MethodTable):
+    visits = 0
+
+    @interp.impl(NestedYield)
+    def yield_stmt(self, interp_, frame, stmt: NestedYield):
+        return interp.YieldValue(frame.get_values(stmt.values))
+
+    @interp.impl(NestedRegion)
+    def region(self, interp_, frame, stmt: NestedRegion):
+        type(self).visits += 1
+        with interp_.new_frame(stmt, has_parent_access=True) as body_frame:
+            results = interp_.frame_call_region(body_frame, stmt, stmt.body)
+        frame.entries.update(body_frame.entries)
+        return results
 
 
 class TestLattice:
@@ -143,6 +189,80 @@ def recurse():
     return ntuple(3)
 
 
+@basic_no_opt
+def loop_carried_conditional_counter(condition: bool) -> int:
+    counter = 0
+    for _ in range(2):
+        if condition:
+            counter += 1
+    return counter
+
+
+@basic_no_opt
+def loop_with_unreachable_dominated_use(condition: bool) -> int:
+    counter = 0
+    for _ in range(2):
+        if condition:
+            counter += 1
+        if False:
+            counter + 10
+    return counter
+
+
+@basic_no_opt
+def loop_carried_pair(condition: bool) -> int:
+    left = 0
+    right = 0
+    for _ in range(2):
+        if condition:
+            left += 1
+            right += 1
+    return left + right
+
+
+@structural_no_opt
+def increment_in_nested_region(counter: int) -> int:
+    if True:
+        counter += 1
+    return counter
+
+
+@basic_no_opt
+def loop_carried_nested_region_counter(condition: bool) -> int:
+    counter = 0
+    for _ in range(2):
+        if condition:
+            counter = increment_in_nested_region(counter)
+    return counter
+
+
+def nested_loop_carried_pair():
+    method = loop_carried_pair.similar(basic_no_opt.add(nested_dialect))
+    body_adds = next(
+        adds
+        for block in method.callable_region.blocks
+        if len(adds := tuple(stmt for stmt in block.stmts if stmt.name == "add")) == 2
+    )
+    nested_add = py.binop.Add(body_adds[0].lhs, body_adds[1].lhs)
+    nested_region = NestedRegion(
+        ir.Region(ir.Block([nested_add, NestedYield(nested_add.result)]))
+    )
+    nested_region.insert_before(body_adds[0])
+    return method, (body_adds[0].lhs, body_adds[1].lhs)
+
+
+def frontend_nested_loop_carried_counter():
+    method = loop_carried_nested_region_counter.similar(structural_no_opt)
+    Walk(Inline(lambda _: True)).rewrite(method.code)
+    nested_add = next(
+        stmt
+        for stmt in method.code.walk()
+        if isinstance(stmt, py.binop.Add)
+        and stmt.parent_region is not method.callable_region
+    )
+    return method, nested_add
+
+
 def test_constprop():
     infer = const.Propagate(basic_no_opt)
     frame, ret = infer.run(main)
@@ -166,6 +286,62 @@ def test_constprop():
     assert ret == const.Unknown()
     _, ret = infer.run(recurse)
     assert ret == const.Value((0, 0, 0))
+
+
+def test_constprop_revisits_dominated_loop_carried_use():
+    method = loop_carried_conditional_counter.similar()
+
+    frame, _ = const.Propagate(method.dialects).run(method)
+    add = next(stmt for stmt in method.code.walk() if stmt.name == "add")
+
+    assert frame.entries[add.result] == const.Unknown()
+
+
+def test_fold_preserves_loop_carried_conditional_counter():
+    method = loop_carried_conditional_counter.similar()
+
+    Fold(method.dialects)(method)
+
+    assert method(True) == 2
+
+
+def test_constprop_revisits_outer_block_for_use_inside_nested_region():
+    method, nested_add = frontend_nested_loop_carried_counter()
+    nested_block = nested_add.parent_block
+    assert nested_block is not None
+    nested_region = nested_block.parent_node
+    assert nested_region is not None
+    region_stmt = nested_region.parent_node
+    assert isinstance(region_stmt, scf.IfElse)
+    outer_block = region_stmt.parent_block
+    assert outer_block is not None
+    assert nested_block is not outer_block
+
+    frame, _ = const.Propagate(method.dialects).run(method)
+
+    assert frame.entries[nested_add.result] == const.Unknown()
+
+
+def test_dependency_generation_deduplicates_pending_visits():
+    method, dependencies = nested_loop_carried_pair()
+    NestedConstProp.visits = 0
+
+    frame, _ = const.Propagate(method.dialects).run(method)
+
+    assert tuple(frame.entries[value] for value in dependencies) == (
+        const.Unknown(),
+        const.Unknown(),
+    )
+    assert NestedConstProp.visits == 2
+
+
+def test_dependency_change_does_not_reach_dead_block():
+    method = loop_with_unreachable_dominated_use.similar()
+    dead_add = tuple(stmt for stmt in method.code.walk() if stmt.name == "add")[-1]
+
+    frame, _ = const.Propagate(method.dialects).run(method)
+
+    assert dead_add.result not in frame.entries
 
 
 @basic_no_opt

--- a/test/analysis/dataflow/typeinfer/test_ssacfg_dependencies.py
+++ b/test/analysis/dataflow/typeinfer/test_ssacfg_dependencies.py
@@ -1,0 +1,45 @@
+from kirin import ir, types, interp, lowering
+from kirin.decl import info, statement
+from kirin.prelude import basic_no_opt
+from kirin.analysis import TypeInference
+
+dialect = ir.Dialect("ssacfg_dependencies")
+T = types.TypeVar("T")
+
+
+@statement(dialect=dialect)
+class TypeIdentity(ir.Statement):
+    name = "identity"
+    traits = frozenset({ir.Pure(), lowering.FromPythonCall()})
+    value: ir.SSAValue = info.argument(T)
+    result: ir.ResultValue = info.result(T)
+
+
+@dialect.register(key="typeinfer")
+class TypeIdentityInference(interp.MethodTable):
+    @interp.impl(TypeIdentity)
+    def identity(self, interp_, frame, stmt: TypeIdentity):
+        return (frame.get(stmt.value),)
+
+
+group = basic_no_opt.add(dialect)
+
+
+@group
+def loop_carried_type(condition: bool):
+    value = 0
+    observed = value
+    for _ in range(2):
+        if condition:
+            observed = TypeIdentity(value)
+            value = 1.0
+    return observed
+
+
+def test_typeinfer_revisits_dominated_loop_carried_use():
+    method = loop_carried_type.similar()
+    identity = next(stmt for stmt in method.code.walk() if stmt.name == "identity")
+
+    frame, _ = TypeInference(method.dialects).run(method)
+
+    assert frame.entries[identity.result] == types.Int.join(types.Float)


### PR DESCRIPTION
Backport of #693 (`f2f8c5b`) to `release-0-22` — fixes the dataflow analysis worklist algorithm, where blocks with non-block-arg SSA dependencies were not re-queued after those dependencies widened, producing incorrect constant-folding results.