### PR TITLE
chore: bump version to 0.22.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kirin-toolchain"
-version = "0.22.11"
+version = "0.22.12"
 description = "The Kirin Toolchain for building compilers and interpreters."
 readme = "README.md"
 requires-python = ">= 3.10"


### PR DESCRIPTION
Kirin 0.22.12 patch release containing backport #678 and #696.