### PR TITLE
fix(ir): stop Method.backedges from leaking discarded clones

### DIFF
--- a/src/kirin/ir/method.py
+++ b/src/kirin/ir/method.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+import weakref
 from types import ModuleType
 
 # from typing import TYPE_CHECKING, Generic, TypeVar, Callable, ParamSpec
@@ -60,7 +61,7 @@ class Method(Printable, typing.Generic[Param, RetType]):
     inferred: bool = False
     """if typeinfer has been run on this method
     """
-    backedges: set[Method] = field(init=False, repr=False)
+    backedges: weakref.WeakSet[Method] = field(init=False, repr=False)
     """Cache for the backedges. (who calls this method)"""
     run_passes: typing.Callable[[Method], None] | None = field(init=False, repr=False)
 
@@ -107,9 +108,9 @@ class Method(Printable, typing.Generic[Param, RetType]):
         self.file = file
         self.lineno_begin = lineno_begin
         self.inferred = inferred
-        self.backedges = set()
-        self.update_backedges()
         self.run_passes = None
+        self.backedges = weakref.WeakSet()
+        self.update_backedges()
 
     def __hash__(self) -> int:
         return id(self)

--- a/src/kirin/serialization/base/deserializer.py
+++ b/src/kirin/serialization/base/deserializer.py
@@ -1,3 +1,4 @@
+import weakref
 from typing import Any, cast
 from dataclasses import field, dataclass
 
@@ -101,7 +102,7 @@ class Deserializer:
             out.mod = None
             out.py_func = None
             out.code = ir.Statement.__new__(ir.Statement)
-            out.backedges = set()
+            out.backedges = weakref.WeakSet()
             out.run_passes = None
             self._ctx.Method_Runtime[mangled] = out
 
@@ -120,7 +121,7 @@ class Deserializer:
         out.dialects = self.dialect_group
 
         out.code = self.deserialize_statement(serUnit.data["code"])
-        out.backedges = set()
+        out.backedges = weakref.WeakSet()
         out.fields = self.deserialize_tuple(serUnit.data.get("fields", ()))
         computed = mangle(
             out.sym_name,

--- a/test/ir/test_backedges.py
+++ b/test/ir/test_backedges.py
@@ -1,0 +1,81 @@
+import gc
+import weakref
+
+from kirin.prelude import basic_no_opt
+
+
+def test_backedges_registers_static_callers():
+    @basic_no_opt
+    def callee(x: int) -> int:
+        return x + 1
+
+    @basic_no_opt
+    def caller(x: int) -> int:
+        return callee(x) * 2
+
+    assert caller in callee.backedges
+
+
+def test_redefinition_recompiles_callers():
+    @basic_no_opt
+    def callee(x: int) -> int:
+        return x + 1
+
+    @basic_no_opt
+    def caller(x: int) -> int:
+        return callee(x) * 2
+
+    assert caller(3) == 8
+
+    @basic_no_opt
+    def callee(x: int) -> int:  # noqa: F811
+        return x + 100
+
+    assert caller(3) == 206
+
+
+def test_backedges_do_not_keep_discarded_clones_alive():
+    """`similar()` clones must not accumulate in their callees' backedges.
+
+    A clone registers itself into the backedges of every method it statically
+    calls, and those callees typically outlive the clone by a lot (they are
+    module level kernels). A strongly referenced `backedges` therefore pins
+    every clone ever made for the lifetime of the callee, which shows up as
+    unbounded heap growth in a compile-per-shot loop.
+    """
+
+    @basic_no_opt
+    def callee(x: int) -> int:
+        return x + 1
+
+    @basic_no_opt
+    def caller(x: int) -> int:
+        return callee(x) * 2
+
+    baseline = len(callee.backedges)
+
+    for _ in range(50):
+        clone = caller.similar()
+        assert clone in callee.backedges
+        del clone
+
+    gc.collect()
+    assert len(callee.backedges) == baseline
+    assert caller in callee.backedges
+
+
+def test_discarded_clone_is_collectable():
+    @basic_no_opt
+    def callee(x: int) -> int:
+        return x + 1
+
+    @basic_no_opt
+    def caller(x: int) -> int:
+        return callee(x) * 2
+
+    clone = caller.similar()
+    ref = weakref.ref(clone)
+    del clone
+
+    gc.collect()
+    assert ref() is None


### PR DESCRIPTION
## Problem

`Method.__init__` calls [`update_backedges()`](https://github.com/QuEraComputing/kirin/blob/main/src/kirin/ir/method.py#L203-L211), which does `callee.backedges.add(self)` for every statically called callee. `backedges` is a strong `set` and nothing ever removes an entry — there is no unregister API.

`similar()` goes through `__init__`, so **every clone registers itself into the backedges of the originals it copies references to**. Note the direction: the clone is not added to the backedges of the method it was cloned *from*, it is added to the backedges of that method's *callees*. Those callees are typically module level kernels that live for the whole program, while the clone is a throwaway.

Concretely, with a callee `C` and a caller `A`:

```python
@basic_no_opt
def C(x: int) -> int:        # the callee
    return x + 1

@basic_no_opt
def A_caller(x: int) -> int:
    return C(x) * 2          # <- static call to C
```

```python
B = A_caller.similar()   # copies A_caller's region, whose Invoke still points at
                         # the *original* C  ->  C.backedges.add(B)
del B                    # refcount 2 -> 1. B is now unreachable to you, and immortal.
```

`B` is never added to `A_caller.backedges` — `B` does not call `A_caller`, it *is a copy of* it. The reference that outlives `del B` is held by `C`, one level down the call graph, which is what makes this easy to miss. If `A_caller` had no static callees, `update_backedges()` would find nothing to register and `del B` would free it normally.

Because a clone owns a full copy of the callable region, and because passes like `bloqade.flair`'s `CallGraphPass` rewire clones to reference each other, a couple of stranded backedge entries transitively pin an entire cloned call graph.

This is a genuine leak rather than GC pressure: after 3 iterations of a clone-and-discard loop, 9 clones survive an explicit `gc.collect()`, and a strong-reference walk starting only from the module level kernels reaches all 9.

## Impact

`CallGraphPass` clones every method in the call graph on each invocation, so a compile-per-shot loop grows the heap without bound. Measured on a 400 statement kernel with two callees:

| | retained per call | max per-call latency | worst gen-2 GC pause |
|---|---|---|---|
| before | 2.76 MB, 3 Methods | 128 ms → **447 ms**, climbing with iteration | 386 ms |
| after | ~0 | flat 94–112 ms | 38 ms |

`callee.backedges` grew linearly with no plateau (2 → 302 over 150 iterations). The rising live heap makes each gen-2 collection more expensive than the last, so this presents as per-iteration latency spikes that get worse the longer you run, rather than as an obvious OOM. Downstream this was missing hardware triggers in a shot loop.

## Fix

Make `backedges` a `weakref.WeakSet`. The field is documented as a cache, and a cache should not decide lifetimes. `Method` is weakref-able, so this is a two line change:

- Real callers are kept alive by whatever defines them (module globals), so they stay in the set and `DialectGroup.recompile_callers` still works on interactive kernel redefinition — covered by a new test.
- Discarded clones are now reclaimed, and CPython's weakref callback drops the dead entry from the set automatically, so no unregister API or `__del__` is needed.
- Forward references are untouched: a clone still strongly references its callees via its `Invoke` statements, as it must to run.

`run_passes` is now assigned before `backedges`, because the dataclass generated `__eq__` can be invoked while adding to the WeakSet and would otherwise see a partially initialized instance (`AttributeError: 'Method' object has no attribute 'run_passes'`).

## Tests

New `test/ir/test_backedges.py`, 4 tests. The two leak tests fail on `main` and pass with the fix; the two behavior-preservation tests pass either way.

Full suite: 516 passed, 13 xfailed, 1 xpassed. Also verified against downstream `bloqade-flair` (1874 passed) and `bloqade-circuit` (1361 passed, 1 pre-existing unrelated `pyqrack` failure that also fails without this patch).

## Note for reviewers

`Method.__hash__` is `id(self)` while the dataclass generated `__eq__` is field-wise, which violates the hash/eq contract. The tempting cleanup — `@dataclass(eq=False)`, giving identity equality consistent with the identity hash — is **not** safe: it breaks `bloqade-circuit`'s `test/analysis/address/test_qubit_analysis.py`, because its address analysis relies on structural `Method` equality through `const.Value`. That inconsistency is load-bearing downstream and is deliberately left alone here.

