### PR TITLE
Reduce serialized IR size and round-trip cost

### DIFF
--- a/src/kirin/serialization/base/context.py
+++ b/src/kirin/serialization/base/context.py
@@ -17,11 +17,20 @@ class MethodSymbolMeta(TypedDict, total=False):
 
 
 @dataclass
+class TypeAttributeSerializationEntry:
+    owner: types.TypeAttribute
+    unit: SerializationUnit
+
+
+@dataclass
 class SerializationContext:
     ssa_idtable: IdTable[ir.SSAValue] = field(default_factory=IdTable[ir.SSAValue])
     stmt_idtable: IdTable[ir.Statement] = field(default_factory=IdTable[ir.Statement])
     blk_idtable: IdTable[ir.Block] = field(default_factory=IdTable[ir.Block])
     region_idtable: IdTable[ir.Region] = field(default_factory=IdTable[ir.Region])
+    type_attribute_idtable: IdTable[int] = field(
+        default_factory=lambda: IdTable[int](prefix="t")
+    )
 
     Dialect_Lookup: dict[str, ir.Dialect] = field(default_factory=dict)
     SSA_Lookup: dict[str, ir.SSAValue] = field(default_factory=dict)
@@ -31,6 +40,15 @@ class SerializationContext:
 
     Method_Symbol: dict[str, MethodSymbolMeta] = field(default_factory=dict)
     Method_Runtime: dict[str, ir.Method] = field(default_factory=dict)
+
+    type_attribute_entries: dict[int, TypeAttributeSerializationEntry] = field(
+        default_factory=dict
+    )
+    TypeAttribute_Definitions: dict[str, SerializationUnit] = field(
+        default_factory=dict
+    )
+    _type_attribute_root: SerializationUnit | None = None
+    _type_attribute_indexed: bool = False
 
     _block_reference_store: dict[str, ir.Block] = field(
         default_factory=dict[str, ir.Block]
@@ -45,10 +63,15 @@ class SerializationContext:
         self.stmt_idtable.clear()
         self.blk_idtable.clear()
         self.region_idtable.clear()
+        self.type_attribute_idtable.clear()
         self._block_reference_store.clear()
         self.Method_Symbol.clear()
         self.Method_Runtime.clear()
         self.Dialect_Lookup.clear()
+        self.type_attribute_entries.clear()
+        self.TypeAttribute_Definitions.clear()
+        self._type_attribute_root = None
+        self._type_attribute_indexed = False
 
 
 def get_str_from_type(typ: types.TypeAttribute) -> str:

--- a/src/kirin/serialization/base/deserializer.py
+++ b/src/kirin/serialization/base/deserializer.py
@@ -2,7 +2,7 @@ import weakref
 from typing import Any, cast
 from dataclasses import field, dataclass
 
-from kirin import ir
+from kirin import ir, types
 from kirin.serialization.base.context import (
     MethodSymbolMeta,
     SerializationContext,
@@ -34,11 +34,17 @@ class Deserializer:
         body = data.body
         if body is None:
             raise ValueError("Module envelope missing body for decoding.")
-        return self.deserialize_method(body)
+        self._ctx._type_attribute_root = body
+        try:
+            return self.deserialize_method(body)
+        finally:
+            self._ctx._type_attribute_root = None
 
     def deserialize(self, serUnit: SerializationUnit) -> Any:
         if serUnit.kind == "ssa_ref":
             return self.deserialize_ssa_ref(serUnit)
+        elif serUnit.kind == "attr_ref":
+            return self.deserialize_attr_ref(serUnit)
         elif serUnit.kind == "attribute":
             return self.deserialize_attribute(serUnit)
         elif serUnit.kind == "type":
@@ -61,6 +67,66 @@ class Deserializer:
             return self._ctx.SSA_Lookup[ssa_id]
         except KeyError:
             raise ValueError(f"dangling ssa_ref {ssa_id!r}") from None
+
+    def deserialize_attr_ref(self, serUnit: SerializationUnit) -> types.TypeAttribute:
+        if not isinstance(serUnit.data, dict):
+            raise ValueError("attr_ref data must be a mapping")
+        try:
+            attr_id = serUnit.data["id"]
+        except KeyError:
+            raise ValueError("attr_ref is missing required 'id'") from None
+        if not isinstance(attr_id, str):
+            raise ValueError(f"attr_ref id must be a string, got {attr_id!r}")
+
+        definition = self._ctx.TypeAttribute_Definitions.get(attr_id)
+        if definition is None:
+            self._index_type_attribute_definitions()
+            try:
+                definition = self._ctx.TypeAttribute_Definitions[attr_id]
+            except KeyError:
+                raise ValueError(f"dangling attr_ref {attr_id!r}") from None
+        return self._deserialize_type_attribute_definition(definition, attr_id)
+
+    def _index_type_attribute_definitions(self) -> None:
+        if self._ctx._type_attribute_indexed:
+            return
+        if self._ctx._type_attribute_root is None:
+            raise ValueError("cannot resolve attr_ref outside Method decoding")
+
+        seen: set[int] = set()
+
+        def visit(value: Any) -> None:
+            if isinstance(value, SerializationUnit):
+                identity = id(value)
+                if identity in seen:
+                    return
+                seen.add(identity)
+
+                if value.kind == "attribute":
+                    if not isinstance(value.data, dict):
+                        raise ValueError("Attribute data must be a mapping")
+                    if "id" in value.data:
+                        attr_id = value.data["id"]
+                        if not isinstance(attr_id, str):
+                            raise ValueError(
+                                f"TypeAttribute definition id must be a string, got {attr_id!r}"
+                            )
+                        existing = self._ctx.TypeAttribute_Definitions.get(attr_id)
+                        if existing is not None and existing is not value:
+                            raise ValueError(
+                                f"duplicate TypeAttribute definition id {attr_id!r}"
+                            )
+                        self._ctx.TypeAttribute_Definitions[attr_id] = value
+                visit(value.data)
+            elif isinstance(value, dict):
+                for item in value.values():
+                    visit(item)
+            elif isinstance(value, (list, tuple)):
+                for item in value:
+                    visit(item)
+
+        visit(self._ctx._type_attribute_root)
+        self._ctx._type_attribute_indexed = True
 
     def generic_deserialize(self, data: SerializationUnit) -> Any:
         if not hasattr(data, "kind"):
@@ -326,9 +392,39 @@ class Deserializer:
         return tuple(self.deserialize(x) for x in serUnit.data.get("value", []))
 
     def deserialize_attribute(self, serUnit: SerializationUnit) -> ir.Attribute:
+        if serUnit.kind == "attr_ref":
+            return self.deserialize_attr_ref(serUnit)
         if serUnit.kind != "attribute":
             raise ValueError(f"Expected kind='attribute', got {serUnit.kind}")
 
+        if not isinstance(serUnit.data, dict):
+            raise ValueError("Attribute data must be a mapping")
+        if "id" not in serUnit.data:
+            return self._deserialize_attribute_full(serUnit)
+
+        attr_id = serUnit.data["id"]
+        if not isinstance(attr_id, str):
+            raise ValueError(
+                f"TypeAttribute definition id must be a string, got {attr_id!r}"
+            )
+        existing = self._ctx.TypeAttribute_Definitions.get(attr_id)
+        if existing is not None and existing is not serUnit:
+            raise ValueError(f"duplicate TypeAttribute definition id {attr_id!r}")
+        self._ctx.TypeAttribute_Definitions[attr_id] = serUnit
+
+        return self._deserialize_type_attribute_definition(serUnit, attr_id)
+
+    def _deserialize_type_attribute_definition(
+        self, serUnit: SerializationUnit, attr_id: str
+    ) -> types.TypeAttribute:
+        attr = self._deserialize_attribute_full(serUnit)
+        if not isinstance(attr, types.TypeAttribute):
+            raise ValueError(
+                f"TypeAttribute definition {attr_id!r} decoded as {type(attr).__name__}"
+            )
+        return attr
+
+    def _deserialize_attribute_full(self, serUnit: SerializationUnit) -> ir.Attribute:
         inner = serUnit.data.get("data")
         if not isinstance(inner, SerializationUnit):
             raise ValueError("Attribute data must contain a SerializationUnit")

--- a/src/kirin/serialization/base/deserializer.py
+++ b/src/kirin/serialization/base/deserializer.py
@@ -37,7 +37,9 @@ class Deserializer:
         return self.deserialize_method(body)
 
     def deserialize(self, serUnit: SerializationUnit) -> Any:
-        if serUnit.kind == "attribute":
+        if serUnit.kind == "ssa_ref":
+            return self.deserialize_ssa_ref(serUnit)
+        elif serUnit.kind == "attribute":
             return self.deserialize_attribute(serUnit)
         elif serUnit.kind == "type":
             return self.deserialize_type(serUnit)
@@ -45,6 +47,20 @@ class Deserializer:
             self, "deserialize_" + serUnit.class_name.lower(), self.generic_deserialize
         )
         return ser_method(serUnit)
+
+    def deserialize_ssa_ref(self, serUnit: SerializationUnit) -> ir.SSAValue:
+        if not isinstance(serUnit.data, dict):
+            raise ValueError("ssa_ref data must be a mapping")
+        try:
+            ssa_id = serUnit.data["id"]
+        except KeyError:
+            raise ValueError("ssa_ref is missing required 'id'") from None
+        if not isinstance(ssa_id, str):
+            raise ValueError(f"ssa_ref id must be a string, got {ssa_id!r}")
+        try:
+            return self._ctx.SSA_Lookup[ssa_id]
+        except KeyError:
+            raise ValueError(f"dangling ssa_ref {ssa_id!r}") from None
 
     def generic_deserialize(self, data: SerializationUnit) -> Any:
         if not hasattr(data, "kind"):

--- a/src/kirin/serialization/base/serializer.py
+++ b/src/kirin/serialization/base/serializer.py
@@ -1,9 +1,10 @@
 from dataclasses import field, dataclass
 
-from kirin import ir
+from kirin import ir, types
 from kirin.serialization.base.context import (
     MethodSymbolMeta,
     SerializationContext,
+    TypeAttributeSerializationEntry,
     mangle,
     get_str_from_type,
 )
@@ -180,18 +181,11 @@ class Serializer:
     def serialize_operand(self, value: ir.SSAValue) -> SerializationUnit:
         if value in self._ctx.ssa_idtable.table:
             return self.serialize_ssa_ref(value)
-
-        if not isinstance(value, ir.BlockArgument):
-            raise ValueError(
-                f"Cannot serialize {type(value).__name__} operand before its "
-                "definition: its owner is external or the IR is not in "
-                "definition order"
-            )
-
-        # A detached nested Method may retain an SSA capture owned by the
-        # defining Method, whose owner is absent from this module. Preserve one
-        # full v1 definition so later uses can still be references.
-        return self.serialize(value)
+        if isinstance(value, ir.ResultValue):
+            return self.serialize_resultvalue(value)
+        if isinstance(value, ir.BlockArgument):
+            return self.serialize_blockargument(value)
+        raise ValueError(f"Unsupported SSA operand type {type(value).__name__}")
 
     def serialize_operand_tuple(
         self, values: tuple[ir.SSAValue, ...]
@@ -411,6 +405,31 @@ class Serializer:
         )
 
     def serialize_attribute(self, attr: ir.Attribute) -> SerializationUnit:
+        if not isinstance(attr, types.TypeAttribute):
+            return self._serialize_attribute_full(attr)
+
+        identity = id(attr)
+        entry = self._ctx.type_attribute_entries.get(identity)
+        if entry is not None:
+            if entry.owner is not attr:
+                raise RuntimeError("TypeAttribute identity table corruption")
+            wire_id = self._ctx.type_attribute_idtable[identity]
+            entry.unit.data["id"] = wire_id
+            return SerializationUnit(
+                kind="attr_ref",
+                module_name="",
+                class_name="",
+                data={"id": wire_id},
+            )
+
+        unit = self._serialize_attribute_full(attr)
+        self._ctx.type_attribute_entries[identity] = TypeAttributeSerializationEntry(
+            owner=attr,
+            unit=unit,
+        )
+        return unit
+
+    def _serialize_attribute_full(self, attr: ir.Attribute) -> SerializationUnit:
         if not isinstance(attr, Serializable):
             raise TypeError(f"Attribute {attr} is not Serializable.")
         return SerializationUnit(

--- a/src/kirin/serialization/base/serializer.py
+++ b/src/kirin/serialization/base/serializer.py
@@ -102,7 +102,6 @@ class Serializer:
             )
 
     def serialize_method(self, mthd: ir.Method) -> SerializationUnit:
-
         mangled = mangle(
             mthd.sym_name,
             getattr(mthd, "arg_types", ()),
@@ -154,13 +153,54 @@ class Serializer:
                 "id": self._ctx.stmt_idtable[stmt],
                 "dialect": self.serialize(stmt.dialect),
                 "name": self.serialize_str(stmt.name),
-                "_args": self.serialize_tuple(stmt._args),
+                "_args": self.serialize_operand_tuple(stmt._args),
                 "_results": self.serialize_list(stmt._results),
                 "_name_args_slice": self.serialize_dict(stmt._name_args_slice),
                 "attributes": self.serialize_dict(stmt.attributes),
                 "successors": self.serialize_list(stmt.successors),
                 "_regions": self.serialize_list(stmt._regions),
             },
+        )
+
+    def serialize_ssa_ref(self, value: ir.SSAValue) -> SerializationUnit:
+        try:
+            ssa_id = self._ctx.ssa_idtable.table[value]
+        except KeyError:
+            raise ValueError(
+                "Cannot serialize an SSA reference before its definition"
+            ) from None
+
+        return SerializationUnit(
+            kind="ssa_ref",
+            module_name="",
+            class_name="",
+            data={"id": ssa_id},
+        )
+
+    def serialize_operand(self, value: ir.SSAValue) -> SerializationUnit:
+        if value in self._ctx.ssa_idtable.table:
+            return self.serialize_ssa_ref(value)
+
+        if not isinstance(value, ir.BlockArgument):
+            raise ValueError(
+                f"Cannot serialize {type(value).__name__} operand before its "
+                "definition: its owner is external or the IR is not in "
+                "definition order"
+            )
+
+        # A detached nested Method may retain an SSA capture owned by the
+        # defining Method, whose owner is absent from this module. Preserve one
+        # full v1 definition so later uses can still be references.
+        return self.serialize(value)
+
+    def serialize_operand_tuple(
+        self, values: tuple[ir.SSAValue, ...]
+    ) -> SerializationUnit:
+        return SerializationUnit(
+            kind="tuple",
+            module_name=tuple.__module__,
+            class_name=tuple.__name__,
+            data={"value": [self.serialize_operand(value) for value in values]},
         )
 
     def serialize_blockargument(self, arg: ir.BlockArgument) -> SerializationUnit:
@@ -214,14 +254,16 @@ class Serializer:
             )
         else:
             self._ctx.Block_Lookup[self._ctx.blk_idtable[block]] = block
+            args = [self.serialize_blockargument(arg) for arg in block.args]
+            stmts = [self.serialize_statement(stmt) for stmt in block.stmts]
             return SerializationUnit(
                 kind="block",
                 module_name=ir.Block.__module__,
                 class_name=ir.Block.__name__,
                 data={
                     "id": self._ctx.blk_idtable[block],
-                    "stmts": [self.serialize_statement(stmt) for stmt in block.stmts],
-                    "_args": [self.serialize_blockargument(arg) for arg in block.args],
+                    "stmts": stmts,
+                    "_args": args,
                 },
             )
 

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -4,6 +4,39 @@ from typing import Any, Optional
 from kirin.serialization.core.serializationunit import SerializationUnit
 from kirin.serialization.core.serializationmodule import SerializationModule
 
+COMPACT_UNIT_TAG = "$u"  # Compact SerializationUnit wrapper.
+ESCAPED_MAP_TAG = "$m"  # Escaped singleton user mapping.
+
+# Descriptors that are part of Kirin's core serialization vocabulary. A
+# descriptor is omitted only when both strings match this table; extensions
+# that reuse a kind with another class keep their full descriptor on the wire.
+STATIC_DESCRIPTORS: dict[str, tuple[str, str]] = {
+    "block": ("kirin.ir.nodes.block", "Block"),
+    "block-arg": ("kirin.ir.ssa", "BlockArgument"),
+    "block_ref": ("kirin.ir.nodes.block", "Block"),
+    "bool": ("builtins", "bool"),
+    "bytearray": ("builtins", "bytearray"),
+    "bytes": ("builtins", "bytes"),
+    "dialect": ("kirin.ir.dialect", "Dialect"),
+    "dialect_group": ("kirin.ir.group", "DialectGroup"),
+    "dict": ("builtins", "dict"),
+    "float": ("builtins", "float"),
+    "frozenset": ("builtins", "frozenset"),
+    "int": ("builtins", "int"),
+    "list": ("builtins", "list"),
+    "method": ("kirin.ir.method", "Method"),
+    "none": ("builtins", "NoneType"),
+    "range": ("builtins", "range"),
+    "region": ("kirin.ir.nodes.region", "Region"),
+    "region_ref": ("kirin.ir.nodes.region", "Region"),
+    "result-value": ("kirin.ir.ssa", "ResultValue"),
+    "set": ("builtins", "set"),
+    "slice": ("builtins", "slice"),
+    "ssa_ref": ("", ""),
+    "str": ("builtins", "str"),
+    "tuple": ("builtins", "tuple"),
+}
+
 
 class JSONtifiable:
     """
@@ -20,15 +53,20 @@ class JSONtifiable:
                 "body": self._to_jsonifiable(obj.body),
             }
         if isinstance(obj, SerializationUnit):
-            return {
-                "__serialization_unit__": True,
-                "kind": obj.kind,
-                "module_name": obj.module_name,
-                "class_name": obj.class_name,
-                "data": self._to_jsonifiable(obj.data),
-            }
+            data = self._to_jsonifiable(obj.data)
+            descriptor = (obj.module_name, obj.class_name)
+            if STATIC_DESCRIPTORS.get(obj.kind) == descriptor:
+                return {COMPACT_UNIT_TAG: [obj.kind, data]}
+            return {COMPACT_UNIT_TAG: [obj.kind, obj.module_name, obj.class_name, data]}
         if isinstance(obj, dict):
-            return {k: self._to_jsonifiable(v) for k, v in obj.items()}
+            encoded = {key: self._to_jsonifiable(value) for key, value in obj.items()}
+            if len(encoded) == 1 and (
+                COMPACT_UNIT_TAG in encoded or ESCAPED_MAP_TAG in encoded
+            ):
+                return {
+                    ESCAPED_MAP_TAG: [[key, value] for key, value in encoded.items()]
+                }
+            return encoded
         if isinstance(obj, (list, tuple)):
             return [self._to_jsonifiable(v) for v in obj]
         return obj
@@ -50,10 +88,74 @@ class JSONtifiable:
                     class_name=obj["class_name"],
                     data=data,
                 )
+            if len(obj) == 1 and COMPACT_UNIT_TAG in obj:
+                return self._decode_compact_unit(obj[COMPACT_UNIT_TAG])
+            if len(obj) == 1 and ESCAPED_MAP_TAG in obj:
+                return self._decode_escaped_mapping(obj[ESCAPED_MAP_TAG])
             return {k: self._from_jsonifiable(v) for k, v in obj.items()}
         if isinstance(obj, list):
             return [self._from_jsonifiable(v) for v in obj]
         return obj
+
+    def _decode_compact_unit(self, payload: Any) -> SerializationUnit:
+        if not isinstance(payload, list) or len(payload) not in (2, 4):
+            raise ValueError(
+                f"{COMPACT_UNIT_TAG} payload must be a 2- or 4-item list, got {payload!r}"
+            )
+
+        kind = payload[0]
+        if not isinstance(kind, str):
+            raise ValueError(f"{COMPACT_UNIT_TAG} kind must be a string, got {kind!r}")
+
+        if len(payload) == 2:
+            descriptor = STATIC_DESCRIPTORS.get(kind)
+            if descriptor is None:
+                raise ValueError(
+                    f"{COMPACT_UNIT_TAG} kind {kind!r} requires module/class descriptors"
+                )
+            module_name, class_name = descriptor
+            raw_data = payload[1]
+        else:
+            module_name, class_name, raw_data = payload[1:]
+            if not isinstance(module_name, str) or not isinstance(class_name, str):
+                raise ValueError(
+                    f"{COMPACT_UNIT_TAG} module/class descriptors must be strings, got "
+                    f"{module_name!r} and {class_name!r}"
+                )
+
+        data = self._from_jsonifiable(raw_data)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{COMPACT_UNIT_TAG} data must decode to a mapping, got {data!r}"
+            )
+        return SerializationUnit(
+            kind=kind,
+            module_name=module_name,
+            class_name=class_name,
+            data=data,
+        )
+
+    def _decode_escaped_mapping(self, payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, list):
+            raise ValueError(
+                f"{ESCAPED_MAP_TAG} payload must be a list, got {payload!r}"
+            )
+
+        result: dict[str, Any] = {}
+        for index, item in enumerate(payload):
+            if not isinstance(item, list) or len(item) != 2:
+                raise ValueError(
+                    f"{ESCAPED_MAP_TAG} item {index} must be a 2-item list, got {item!r}"
+                )
+            key, value = item
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"{ESCAPED_MAP_TAG} item {index} key must be a string, got {key!r}"
+                )
+            if key in result:
+                raise ValueError(f"{ESCAPED_MAP_TAG} contains duplicate key {key!r}")
+            result[key] = self._from_jsonifiable(value)
+        return result
 
 
 class JSONSerializer(JSONtifiable):

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -11,6 +11,7 @@ ESCAPED_MAP_TAG = "$m"  # Escaped singleton user mapping.
 # descriptor is omitted only when both strings match this table; extensions
 # that reuse a kind with another class keep their full descriptor on the wire.
 STATIC_DESCRIPTORS: dict[str, tuple[str, str]] = {
+    "attr_ref": ("", ""),
     "block": ("kirin.ir.nodes.block", "Block"),
     "block-arg": ("kirin.ir.ssa", "BlockArgument"),
     "block_ref": ("kirin.ir.nodes.block", "Block"),
@@ -71,30 +72,50 @@ class JSONtifiable:
             return [self._to_jsonifiable(v) for v in obj]
         return obj
 
-    def _from_jsonifiable(self, obj: Any) -> Any:
+    def _from_jsonifiable(self, obj: Any, *, allow_compact_tags: bool = True) -> Any:
         if isinstance(obj, dict):
             if obj.get("__serialization_module__"):
-                symbol_table = self._from_jsonifiable(obj.get("symbol_table", {}))
-                body = self._from_jsonifiable(obj.get("body"))
+                raw_body = obj.get("body")
+                is_verbose = isinstance(raw_body, dict) and bool(
+                    raw_body.get("__serialization_unit__")
+                )
+                child_allow_compact_tags = allow_compact_tags and not is_verbose
+                symbol_table = self._from_jsonifiable(
+                    obj.get("symbol_table", {}),
+                    allow_compact_tags=child_allow_compact_tags,
+                )
+                body = self._from_jsonifiable(
+                    raw_body, allow_compact_tags=child_allow_compact_tags
+                )
                 version = obj.get("version", "")
                 return SerializationModule(
                     symbol_table=symbol_table, body=body, version=version
                 )
             if obj.get("__serialization_unit__"):
-                data = self._from_jsonifiable(obj.get("data", {}))
+                data = self._from_jsonifiable(
+                    obj.get("data", {}), allow_compact_tags=False
+                )
                 return SerializationUnit(
                     kind=obj["kind"],
                     module_name=obj["module_name"],
                     class_name=obj["class_name"],
                     data=data,
                 )
-            if len(obj) == 1 and COMPACT_UNIT_TAG in obj:
+            if allow_compact_tags and len(obj) == 1 and COMPACT_UNIT_TAG in obj:
                 return self._decode_compact_unit(obj[COMPACT_UNIT_TAG])
-            if len(obj) == 1 and ESCAPED_MAP_TAG in obj:
+            if allow_compact_tags and len(obj) == 1 and ESCAPED_MAP_TAG in obj:
                 return self._decode_escaped_mapping(obj[ESCAPED_MAP_TAG])
-            return {k: self._from_jsonifiable(v) for k, v in obj.items()}
+            return {
+                key: self._from_jsonifiable(
+                    value, allow_compact_tags=allow_compact_tags
+                )
+                for key, value in obj.items()
+            }
         if isinstance(obj, list):
-            return [self._from_jsonifiable(v) for v in obj]
+            return [
+                self._from_jsonifiable(value, allow_compact_tags=allow_compact_tags)
+                for value in obj
+            ]
         return obj
 
     def _decode_compact_unit(self, payload: Any) -> SerializationUnit:

--- a/test/serialization/test_compact_codec.py
+++ b/test/serialization/test_compact_codec.py
@@ -1,0 +1,385 @@
+import gzip
+import json
+from typing import Any
+from collections.abc import Callable
+
+import bson
+import pytest
+
+from kirin import ir
+from kirin.serialization.bsonserializer import CompressedBSONSerializer
+from kirin.serialization.jsonserializer import JSONtifiable, JSONSerializer
+from kirin.serialization.core.serializationunit import SerializationUnit
+from kirin.serialization.core.serializationmodule import SerializationModule
+
+Transport = tuple[
+    Callable[[SerializationModule], str | bytes],
+    Callable[[str | bytes], SerializationModule],
+    Callable[[str | bytes], dict[str, Any]],
+]
+
+
+def _json_transport() -> Transport:
+    serializer = JSONSerializer()
+    return serializer.encode, serializer.decode, json.loads
+
+
+def _bson_transport() -> Transport:
+    serializer = CompressedBSONSerializer()
+
+    def load(payload: str | bytes) -> dict[str, Any]:
+        assert isinstance(payload, bytes)
+        return bson.decode(gzip.decompress(payload))
+
+    return serializer.encode, serializer.decode, load
+
+
+@pytest.fixture(params=[_json_transport, _bson_transport], ids=["json", "bson"])
+def transport(request: pytest.FixtureRequest) -> Transport:
+    return request.param()
+
+
+def _module(body: SerializationUnit, *, version: str = "") -> SerializationModule:
+    return SerializationModule(symbol_table={}, body=body, version=version)
+
+
+def _assert_unit_equal(actual: SerializationUnit, expected: SerializationUnit) -> None:
+    assert actual.kind == expected.kind
+    assert actual.module_name == expected.module_name
+    assert actual.class_name == expected.class_name
+    _assert_value_equal(actual.data, expected.data)
+
+
+def _assert_value_equal(actual: Any, expected: Any) -> None:
+    if isinstance(expected, SerializationUnit):
+        assert isinstance(actual, SerializationUnit)
+        _assert_unit_equal(actual, expected)
+        return
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict)
+        assert actual.keys() == expected.keys()
+        for key, value in expected.items():
+            _assert_value_equal(actual[key], value)
+        return
+    if isinstance(expected, (list, tuple)):
+        assert isinstance(actual, (list, tuple))
+        assert len(actual) == len(expected)
+        for actual_item, expected_item in zip(actual, expected):
+            _assert_value_equal(actual_item, expected_item)
+        return
+    assert actual == expected
+
+
+STATIC_UNITS = [
+    pytest.param("bool", "builtins", "bool", {"value": "True"}, id="bool"),
+    pytest.param("bytes", "builtins", "bytes", {"value": "00ff"}, id="bytes"),
+    pytest.param(
+        "bytearray", "builtins", "bytearray", {"value": "00ff"}, id="bytearray"
+    ),
+    pytest.param("dict", "builtins", "dict", {"keys": [], "values": []}, id="dict"),
+    pytest.param("float", "builtins", "float", {"value": "-0.0"}, id="float"),
+    pytest.param("frozenset", "builtins", "frozenset", {"value": []}, id="frozenset"),
+    pytest.param("int", "builtins", "int", {"value": "-7"}, id="int"),
+    pytest.param("list", "builtins", "list", {"value": []}, id="list"),
+    pytest.param("none", "builtins", "NoneType", {}, id="none"),
+    pytest.param(
+        "range",
+        "builtins",
+        "range",
+        {
+            "start": SerializationUnit("int", "builtins", "int", {"value": "1"}),
+            "stop": SerializationUnit("int", "builtins", "int", {"value": "5"}),
+            "step": SerializationUnit("int", "builtins", "int", {"value": "2"}),
+        },
+        id="range",
+    ),
+    pytest.param("set", "builtins", "set", {"value": []}, id="set"),
+    pytest.param(
+        "slice",
+        "builtins",
+        "slice",
+        {
+            "start": SerializationUnit("int", "builtins", "int", {"value": "1"}),
+            "stop": SerializationUnit("none", "builtins", "NoneType", {}),
+            "step": SerializationUnit("int", "builtins", "int", {"value": "-1"}),
+        },
+        id="slice",
+    ),
+    pytest.param("str", "builtins", "str", {"value": "Kirin"}, id="str"),
+    pytest.param("tuple", "builtins", "tuple", {"value": []}, id="tuple"),
+    pytest.param("method", ir.Method.__module__, ir.Method.__name__, {}, id="method"),
+    pytest.param(
+        "block-arg",
+        ir.BlockArgument.__module__,
+        ir.BlockArgument.__name__,
+        {},
+        id="block-arg",
+    ),
+    pytest.param("region", ir.Region.__module__, ir.Region.__name__, {}, id="region"),
+    pytest.param(
+        "region_ref", ir.Region.__module__, ir.Region.__name__, {}, id="region-ref"
+    ),
+    pytest.param("block", ir.Block.__module__, ir.Block.__name__, {}, id="block"),
+    pytest.param(
+        "block_ref", ir.Block.__module__, ir.Block.__name__, {}, id="block-ref"
+    ),
+    pytest.param(
+        "result-value",
+        ir.ResultValue.__module__,
+        ir.ResultValue.__name__,
+        {},
+        id="result-value",
+    ),
+    pytest.param(
+        "dialect", ir.Dialect.__module__, ir.Dialect.__name__, {}, id="dialect"
+    ),
+    pytest.param(
+        "dialect_group",
+        ir.DialectGroup.__module__,
+        ir.DialectGroup.__name__,
+        {},
+        id="dialect-group",
+    ),
+]
+
+
+@pytest.mark.parametrize(("kind", "module_name", "class_name", "data"), STATIC_UNITS)
+def test_static_units_use_short_compact_shape_and_round_trip(
+    transport: Transport,
+    kind: str,
+    module_name: str,
+    class_name: str,
+    data: dict[str, Any],
+) -> None:
+    encode, decode, load = transport
+    unit = SerializationUnit(kind, module_name, class_name, data)
+
+    payload = encode(_module(unit))
+    wire = load(payload)
+
+    assert wire["body"] == {"$u": [kind, wire["body"]["$u"][1]]}
+    assert len(wire["body"]["$u"]) == 2
+    decoded = decode(payload)
+    _assert_unit_equal(decoded.body, unit)
+
+
+DYNAMIC_UNITS = [
+    pytest.param(
+        "statement", "test.dialect", "ExampleStatement", {"id": "stmt0"}, id="statement"
+    ),
+    pytest.param(
+        "attribute",
+        "test.dialect",
+        "ExampleAttribute",
+        {"data": SerializationUnit("none", "builtins", "NoneType", {})},
+        id="attribute",
+    ),
+    pytest.param("type", "test.types", "ExampleType", {}, id="type"),
+    pytest.param(
+        "dialect",
+        "test.dialect",
+        "ExampleDialect",
+        {"name": "test"},
+        id="dialect-subclass",
+    ),
+    pytest.param(
+        "ilist", "test.extension", "ExampleIList", {"data": []}, id="extension"
+    ),
+    pytest.param("custom", "test.extension", "CustomUnit", {"answer": 42}, id="custom"),
+    pytest.param(
+        "int",
+        "test.extension",
+        "CustomInteger",
+        {"value": "7"},
+        id="known-kind-custom-descriptor",
+    ),
+]
+
+
+@pytest.mark.parametrize(("kind", "module_name", "class_name", "data"), DYNAMIC_UNITS)
+def test_dynamic_units_keep_descriptors_and_round_trip(
+    transport: Transport,
+    kind: str,
+    module_name: str,
+    class_name: str,
+    data: dict[str, Any],
+) -> None:
+    encode, decode, load = transport
+    unit = SerializationUnit(kind, module_name, class_name, data)
+
+    payload = encode(_module(unit))
+    wire = load(payload)
+
+    assert wire["body"]["$u"][:3] == [kind, module_name, class_name]
+    assert len(wire["body"]["$u"]) == 4
+    decoded = decode(payload)
+    _assert_unit_equal(decoded.body, unit)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({"$u": ["int", {"value": "5"}]}, id="unit-tag"),
+        pytest.param({"$m": [["user", "value"]]}, id="map-tag"),
+        pytest.param({"$u": {"$m": "nested-user-data"}}, id="nested-tags"),
+    ],
+)
+def test_exact_control_tag_collisions_are_escaped_once_and_round_trip(
+    transport: Transport, data: dict[str, Any]
+) -> None:
+    encode, decode, load = transport
+    unit = SerializationUnit("custom", "test.extension", "CustomUnit", data)
+
+    payload = encode(_module(unit))
+    wire_data = load(payload)["body"]["$u"][3]
+
+    assert list(wire_data) == ["$m"]
+    assert wire_data["$m"][0][0] == next(iter(data))
+    decoded = decode(payload)
+    _assert_unit_equal(decoded.body, unit)
+
+
+def test_nested_collisions_are_escaped_without_changing_ordinary_maps() -> None:
+    codec = JSONtifiable()
+    value = {
+        "ordinary": {"$u": ["int", {"value": "5"}]},
+        "nested": {"deeper": {"$m": [["user", "value"]]}},
+    }
+
+    wire = codec._to_jsonifiable(value)
+
+    assert wire == {
+        "ordinary": {"$m": [["$u", ["int", {"value": "5"}]]]},
+        "nested": {
+            "deeper": {"$m": [["$m", [["user", "value"]]]]},
+        },
+    }
+    assert codec._from_jsonifiable(wire) == value
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"$u": None}, id="unit-not-list"),
+        pytest.param({"$u": []}, id="unit-empty"),
+        pytest.param({"$u": ["int"]}, id="unit-too-short"),
+        pytest.param({"$u": ["int", {}, "extra"]}, id="unit-length-three"),
+        pytest.param(
+            {"$u": ["int", "builtins", "int", {}, "extra"]}, id="unit-too-long"
+        ),
+        pytest.param({"$u": [1, {}]}, id="unit-kind-not-string"),
+        pytest.param({"$u": ["unknown", {}]}, id="unknown-short-unit"),
+        pytest.param({"$u": ["int", []]}, id="unit-data-not-map"),
+        pytest.param({"$u": ["custom", 1, "Custom", {}]}, id="module-not-string"),
+        pytest.param(
+            {"$u": ["custom", "test.extension", 1, {}]}, id="class-not-string"
+        ),
+        pytest.param({"$m": None}, id="map-not-list"),
+        pytest.param({"$m": ["not-a-pair"]}, id="map-entry-not-list"),
+        pytest.param({"$m": [["key"]]}, id="map-pair-too-short"),
+        pytest.param({"$m": [["key", 1, 2]]}, id="map-pair-too-long"),
+        pytest.param({"$m": [[1, "value"]]}, id="map-key-not-string"),
+        pytest.param({"$m": [["key", 1], ["key", 2]]}, id="duplicate-map-key"),
+    ],
+)
+def test_malformed_exact_control_shapes_are_rejected(payload: dict[str, Any]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        JSONtifiable()._from_jsonifiable(payload)
+
+
+@pytest.mark.parametrize("tag", ["$u", "$m"])
+def test_control_key_with_siblings_is_an_ordinary_mapping(tag: str) -> None:
+    value = {tag: "not-a-control-record", "user": True}
+    assert JSONtifiable()._from_jsonifiable(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(-(2**63) - 1, id="below-int64"),
+        pytest.param(-(2**63), id="int64-min"),
+        pytest.param(2**63 - 1, id="int64-max"),
+        pytest.param(2**63, id="above-int64"),
+        pytest.param(2**4096 + 1, id="arbitrary-precision"),
+    ],
+)
+def test_integer_payload_stays_a_string_through_public_transports(
+    transport: Transport, value: int
+) -> None:
+    encode, decode, load = transport
+    unit = SerializationUnit("int", "builtins", "int", {"value": str(value)})
+
+    payload = encode(_module(unit))
+    wire_value = load(payload)["body"]["$u"][1]["value"]
+
+    assert wire_value == str(value)
+    assert isinstance(wire_value, str)
+    assert int(decode(payload).body.data["value"]) == value
+
+
+@pytest.mark.parametrize(
+    "version",
+    [pytest.param("", id="empty"), pytest.param("caller-v9.4+🦉", id="arbitrary")],
+)
+def test_public_transports_preserve_caller_version(
+    transport: Transport, version: str
+) -> None:
+    encode, decode, load = transport
+    module = _module(
+        SerializationUnit("none", "builtins", "NoneType", {}), version=version
+    )
+
+    payload = encode(module)
+
+    assert load(payload)["version"] == version
+    assert decode(payload).version == version
+
+
+VERBOSE_INT = {
+    "__serialization_unit__": True,
+    "kind": "int",
+    "module_name": "builtins",
+    "class_name": "int",
+    "data": {"value": str(2**256 + 1)},
+}
+VERBOSE_MODULE = {
+    "__serialization_module__": True,
+    "version": "legacy-caller-version",
+    "symbol_table": {},
+    "body": {
+        "__serialization_unit__": True,
+        "kind": "list",
+        "module_name": "builtins",
+        "class_name": "list",
+        "data": {"value": [VERBOSE_INT]},
+    },
+}
+
+
+@pytest.mark.parametrize("transport_name", ["json", "bson"])
+def test_public_readers_accept_verbose_v1_and_reencode_compact(
+    transport_name: str,
+) -> None:
+    if transport_name == "json":
+        serializer = JSONSerializer()
+        decoded = serializer.decode(json.dumps(VERBOSE_MODULE))
+        compact_wire = json.loads(serializer.encode(decoded))
+    else:
+        serializer = CompressedBSONSerializer()
+        payload = gzip.compress(bson.encode(VERBOSE_MODULE), mtime=0)
+        decoded = serializer.decode(payload)
+        compact_wire = bson.decode(gzip.decompress(serializer.encode(decoded)))
+
+    assert decoded.version == "legacy-caller-version"
+    assert decoded.body.kind == "list"
+    assert decoded.body.data["value"][0].data["value"] == str(2**256 + 1)
+    assert set(compact_wire["body"]) == {"$u"}
+
+
+def test_missing_verbose_version_keeps_the_existing_empty_default() -> None:
+    payload = dict(VERBOSE_MODULE)
+    payload.pop("version")
+
+    decoded = JSONSerializer().decode(json.dumps(payload))
+
+    assert decoded.version == ""

--- a/test/serialization/test_compact_codec.py
+++ b/test/serialization/test_compact_codec.py
@@ -344,7 +344,7 @@ VERBOSE_INT = {
 }
 VERBOSE_MODULE = {
     "__serialization_module__": True,
-    "version": "legacy-caller-version",
+    "version": "caller-version",
     "symbol_table": {},
     "body": {
         "__serialization_unit__": True,
@@ -361,7 +361,7 @@ VERBOSE_CONTROL_TAG_DATA = {
 }
 VERBOSE_CONTROL_TAG_MODULE = {
     "__serialization_module__": True,
-    "version": "legacy-control-tags",
+    "version": "caller-version",
     "symbol_table": {},
     "body": {
         "__serialization_unit__": True,
@@ -387,7 +387,7 @@ def test_public_readers_accept_verbose_v1_and_reencode_compact(
         decoded = serializer.decode(payload)
         compact_wire = bson.decode(gzip.decompress(serializer.encode(decoded)))
 
-    assert decoded.version == "legacy-caller-version"
+    assert decoded.version == "caller-version"
     assert decoded.body.kind == "list"
     assert decoded.body.data["value"][0].data["value"] == str(2**256 + 1)
     assert set(compact_wire["body"]) == {"$u"}

--- a/test/serialization/test_compact_codec.py
+++ b/test/serialization/test_compact_codec.py
@@ -355,6 +355,23 @@ VERBOSE_MODULE = {
     },
 }
 
+VERBOSE_CONTROL_TAG_DATA = {
+    "unit-shaped": {"$u": ["int", {"value": "5"}]},
+    "map-shaped": {"$m": [["user", "value"]]},
+}
+VERBOSE_CONTROL_TAG_MODULE = {
+    "__serialization_module__": True,
+    "version": "legacy-control-tags",
+    "symbol_table": {},
+    "body": {
+        "__serialization_unit__": True,
+        "kind": "custom",
+        "module_name": "test.extension",
+        "class_name": "CustomUnit",
+        "data": VERBOSE_CONTROL_TAG_DATA,
+    },
+}
+
 
 @pytest.mark.parametrize("transport_name", ["json", "bson"])
 def test_public_readers_accept_verbose_v1_and_reencode_compact(
@@ -374,6 +391,19 @@ def test_public_readers_accept_verbose_v1_and_reencode_compact(
     assert decoded.body.kind == "list"
     assert decoded.body.data["value"][0].data["value"] == str(2**256 + 1)
     assert set(compact_wire["body"]) == {"$u"}
+
+
+@pytest.mark.parametrize("transport_name", ["json", "bson"])
+def test_verbose_v1_control_tag_shaped_mappings_remain_literal(
+    transport_name: str,
+) -> None:
+    if transport_name == "json":
+        module = JSONSerializer().decode(json.dumps(VERBOSE_CONTROL_TAG_MODULE))
+    else:
+        payload = gzip.compress(bson.encode(VERBOSE_CONTROL_TAG_MODULE), mtime=0)
+        module = CompressedBSONSerializer().decode(payload)
+
+    assert module.body.data == VERBOSE_CONTROL_TAG_DATA
 
 
 def test_missing_verbose_version_keeps_the_existing_empty_default() -> None:

--- a/test/serialization/test_ssa_refs.py
+++ b/test/serialization/test_ssa_refs.py
@@ -72,24 +72,6 @@ def detached_capture_caller(x: int) -> int:
     return detached_capture(x)
 
 
-@basic_no_opt
-def make_detached_result_capture(y: int):
-    captured = y + 1
-
-    def inner(x: int) -> int:
-        return x * captured
-
-    return inner
-
-
-detached_result_capture = make_detached_result_capture(y=10)
-
-
-@basic_no_opt
-def detached_result_capture_caller(x: int) -> int:
-    return detached_result_capture(x)
-
-
 Transport = Literal["module", "json", "cbson"]
 TRANSPORTS: tuple[Transport, ...] = ("module", "json", "cbson")
 
@@ -308,17 +290,6 @@ def test_detached_capture_keeps_one_full_external_definition(
 
     decoded.verify()
     assert decoded(3) == detached_capture_caller(3) == 31
-
-
-def test_external_result_capture_fails_before_writing_an_undecodable_payload() -> None:
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Cannot serialize ResultValue operand before its definition: its owner "
-            "is external or the IR is not in definition order"
-        ),
-    ):
-        detached_result_capture_caller.dialects.encode(detached_result_capture_caller)
 
 
 def test_ssa_ref_does_not_allocate_an_id_for_an_undefined_value() -> None:

--- a/test/serialization/test_ssa_refs.py
+++ b/test/serialization/test_ssa_refs.py
@@ -1,0 +1,441 @@
+"""SSA operand-reference serialization and use-def reconstruction tests."""
+
+from __future__ import annotations
+
+import copy
+import gzip
+import json
+from typing import Any, Literal
+from collections.abc import Iterator
+
+import bson
+import pytest
+
+from kirin import ir
+from kirin.prelude import basic_no_opt
+from kirin.serialization.bsonserializer import CompressedBSONSerializer
+from kirin.serialization.jsonserializer import JSONSerializer
+from kirin.serialization.base.serializer import Serializer
+from kirin.serialization.core.serializationunit import SerializationUnit
+from kirin.serialization.core.serializationmodule import SerializationModule
+
+
+@basic_no_opt
+def straight_line(x: int) -> int:
+    y = x + 1
+    return y * 2
+
+
+@basic_no_opt
+def branching(x: int, flag: bool) -> int:
+    if flag:
+        y = x + 1
+    else:
+        y = x - 1
+    return y * 2
+
+
+@basic_no_opt
+def looping(n: int) -> int:
+    acc = 0
+    for i in range(n):
+        acc = acc + i
+    return acc
+
+
+@basic_no_opt
+def nested_capture(y: int) -> int:
+    def inner(x: int) -> int:
+        return x * y + 1
+
+    return inner(3)
+
+
+@basic_no_opt
+def repeated_operand(x: int) -> int:
+    return x + x
+
+
+@basic_no_opt
+def make_detached_capture(y: int):
+    def inner(x: int) -> int:
+        return x * y + 1
+
+    return inner
+
+
+detached_capture = make_detached_capture(y=10)
+
+
+@basic_no_opt
+def detached_capture_caller(x: int) -> int:
+    return detached_capture(x)
+
+
+@basic_no_opt
+def make_detached_result_capture(y: int):
+    captured = y + 1
+
+    def inner(x: int) -> int:
+        return x * captured
+
+    return inner
+
+
+detached_result_capture = make_detached_result_capture(y=10)
+
+
+@basic_no_opt
+def detached_result_capture_caller(x: int) -> int:
+    return detached_result_capture(x)
+
+
+Transport = Literal["module", "json", "cbson"]
+TRANSPORTS: tuple[Transport, ...] = ("module", "json", "cbson")
+
+KERNELS = (
+    pytest.param(straight_line, ((3,),), id="straight-line"),
+    pytest.param(branching, ((3, True), (3, False)), id="branching-cfg"),
+    pytest.param(looping, ((0,), (5,)), id="loop-block-args"),
+    pytest.param(nested_capture, ((4,),), id="nested-capture"),
+)
+
+
+def _walk_units(value: Any) -> Iterator[SerializationUnit]:
+    if isinstance(value, SerializationUnit):
+        yield value
+        yield from _walk_units(value.data)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _walk_units(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _walk_units(item)
+
+
+def _walk_wire(value: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from _walk_wire(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_wire(item)
+
+
+def _through_transport(
+    module: SerializationModule, transport: Transport
+) -> SerializationModule:
+    if transport == "module":
+        return module
+    if transport == "json":
+        codec = JSONSerializer()
+        return codec.decode(codec.encode(module))
+
+    codec = CompressedBSONSerializer()
+    return codec.decode(codec.encode(module))
+
+
+def _round_trip(
+    method: ir.Method, transport: Transport
+) -> tuple[SerializationModule, ir.Method]:
+    module = _through_transport(method.dialects.encode(method), transport)
+    return module, method.dialects.decode(module)
+
+
+def _walk_blocks(statement: ir.Statement) -> Iterator[ir.Block]:
+    for region in statement.regions:
+        for block in region.blocks:
+            yield block
+            for child in block.stmts:
+                yield from _walk_blocks(child)
+
+
+def _assert_exact_reverse_uses(method: ir.Method) -> None:
+    values: set[ir.SSAValue] = set()
+    expected: dict[ir.SSAValue, set[ir.Use]] = {}
+
+    for block in _walk_blocks(method.code):
+        values.update(block.args)
+        for stmt in block.stmts:
+            values.update(stmt.results)
+            values.update(stmt.args)
+            for index, operand in enumerate(stmt.args):
+                expected.setdefault(operand, set()).add(ir.Use(stmt, index))
+
+    for value in values:
+        assert value.uses == expected.get(value, set())
+
+
+def _assert_operand_refs_and_owner_definitions(module: SerializationModule) -> None:
+    units = list(_walk_units(module.body))
+    statements = [unit for unit in units if unit.kind == "statement"]
+    blocks = [unit for unit in units if unit.kind == "block"]
+    assert statements
+    assert blocks
+
+    operand_refs: list[SerializationUnit] = []
+    result_definitions: list[SerializationUnit] = []
+    block_arg_definitions: list[SerializationUnit] = []
+
+    for statement in statements:
+        operands = statement.data["_args"]
+        assert isinstance(operands, SerializationUnit)
+        assert operands.kind == "tuple"
+        encoded_operands = operands.data["value"]
+        assert all(operand.kind == "ssa_ref" for operand in encoded_operands)
+        operand_refs.extend(encoded_operands)
+
+        results = statement.data["_results"]
+        assert isinstance(results, SerializationUnit)
+        assert results.kind == "list"
+        encoded_results = results.data["value"]
+        assert all(result.kind == "result-value" for result in encoded_results)
+        result_definitions.extend(encoded_results)
+
+    for block in blocks:
+        encoded_args = block.data["_args"]
+        assert all(arg.kind == "block-arg" for arg in encoded_args)
+        block_arg_definitions.extend(encoded_args)
+
+    assert operand_refs
+    assert result_definitions
+    assert block_arg_definitions
+
+    definitions = [*block_arg_definitions, *result_definitions]
+    definition_ids = [definition.data["id"] for definition in definitions]
+    assert all(isinstance(ssa_id, str) for ssa_id in definition_ids)
+    assert len(definition_ids) == len(set(definition_ids))
+
+    for reference in operand_refs:
+        assert reference.module_name == ""
+        assert reference.class_name == ""
+        assert set(reference.data) == {"id"}
+        assert isinstance(reference.data["id"], str)
+        assert reference.data["id"] in definition_ids
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+@pytest.mark.parametrize(("kernel", "argument_sets"), KERNELS)
+def test_ssa_refs_round_trip_real_ir_shapes(
+    kernel: ir.Method,
+    argument_sets: tuple[tuple[object, ...], ...],
+    transport: Transport,
+) -> None:
+    _assert_exact_reverse_uses(kernel)
+    module, decoded = _round_trip(kernel, transport)
+
+    _assert_operand_refs_and_owner_definitions(module)
+    _assert_exact_reverse_uses(decoded)
+    decoded.verify()
+    assert decoded.code.is_structurally_equal(kernel.code)
+    for args in argument_sets:
+        assert decoded(*args) == kernel(*args)
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_repeated_operand_preserves_identity_and_both_use_indices(
+    transport: Transport,
+) -> None:
+    module, decoded = _round_trip(repeated_operand, transport)
+    _assert_operand_refs_and_owner_definitions(module)
+
+    (add,) = (stmt for stmt in decoded.code.walk() if stmt.name == "add")
+    lhs, rhs = add.args
+    assert lhs is rhs
+    assert lhs.uses == {ir.Use(add, 0), ir.Use(add, 1)}
+    _assert_exact_reverse_uses(decoded)
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_reordered_reachable_blocks_round_trip(transport: Transport) -> None:
+    method = branching.similar()
+    region = method.callable_region
+    blocks = list(region.blocks)
+    assert len(blocks) > 2
+
+    region._blocks[:] = [blocks[0], *reversed(blocks[1:])]
+    region._block_idx = {block: index for index, block in enumerate(region.blocks)}
+
+    module, decoded = _round_trip(method, transport)
+    _assert_operand_refs_and_owner_definitions(module)
+    _assert_exact_reverse_uses(decoded)
+    decoded.verify()
+    assert decoded.code.is_structurally_equal(method.code)
+    assert decoded(3, True) == method(3, True)
+    assert decoded(3, False) == method(3, False)
+
+
+@pytest.mark.parametrize("transport", ["json", "cbson"])
+def test_ssa_ref_uses_short_compact_wire_shape(transport: str) -> None:
+    module = repeated_operand.dialects.encode(repeated_operand)
+    if transport == "json":
+        wire = json.loads(JSONSerializer().encode(module))
+    else:
+        encoded = CompressedBSONSerializer().encode(module)
+        wire = bson.decode(gzip.decompress(encoded))
+
+    refs = [
+        mapping["$u"]
+        for mapping in _walk_wire(wire)
+        if len(mapping) == 1 and "$u" in mapping and mapping["$u"][0] == "ssa_ref"
+    ]
+    assert refs
+    assert all(len(ref) == 2 and set(ref[1]) == {"id"} for ref in refs)
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_detached_capture_keeps_one_full_external_definition(
+    transport: Transport,
+) -> None:
+    module, decoded = _round_trip(detached_capture_caller, transport)
+    statements = [unit for unit in _walk_units(module.body) if unit.kind == "statement"]
+    operands = [
+        operand
+        for statement in statements
+        for operand in statement.data["_args"].data["value"]
+    ]
+
+    external_definitions = [
+        operand for operand in operands if operand.kind == "block-arg"
+    ]
+    assert len(external_definitions) == 1
+    assert external_definitions[0].data["name"] == "y"
+    assert all(
+        operand.kind == "ssa_ref" or operand is external_definitions[0]
+        for operand in operands
+    )
+
+    decoded.verify()
+    assert decoded(3) == detached_capture_caller(3) == 31
+
+
+def test_external_result_capture_fails_before_writing_an_undecodable_payload() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot serialize ResultValue operand before its definition: its owner "
+            "is external or the IR is not in definition order"
+        ),
+    ):
+        detached_result_capture_caller.dialects.encode(detached_result_capture_caller)
+
+
+def test_ssa_ref_does_not_allocate_an_id_for_an_undefined_value() -> None:
+    serializer = Serializer()
+    value = ir.TestValue()
+
+    with pytest.raises(
+        ValueError, match="Cannot serialize an SSA reference before its definition"
+    ):
+        serializer.serialize_ssa_ref(value)
+
+    assert value not in serializer._ctx.ssa_idtable.table
+
+
+MALFORMED_REFS = (
+    pytest.param({}, r"ssa_ref is missing required 'id'", id="missing-id"),
+    pytest.param(
+        {"id": 17}, r"ssa_ref id must be a string, got 17", id="non-string-id"
+    ),
+    pytest.param(
+        {"id": "not-defined"},
+        r"dangling ssa_ref 'not-defined'",
+        id="dangling-id",
+    ),
+)
+
+
+def test_ssa_ref_data_must_be_a_mapping() -> None:
+    module = straight_line.dialects.encode(straight_line)
+    reference = next(
+        unit for unit in _walk_units(module.body) if unit.kind == "ssa_ref"
+    )
+    reference.data = None  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="ssa_ref data must be a mapping"):
+        straight_line.dialects.decode(module)
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+@pytest.mark.parametrize(("bad_data", "error"), MALFORMED_REFS)
+def test_malformed_ssa_refs_fail_with_context(
+    bad_data: dict[str, object], error: str, transport: Transport
+) -> None:
+    module = straight_line.dialects.encode(straight_line)
+    reference = next(
+        unit for unit in _walk_units(module.body) if unit.kind == "ssa_ref"
+    )
+    reference.data = bad_data
+    module = _through_transport(module, transport)
+
+    with pytest.raises(ValueError, match=error):
+        straight_line.dialects.decode(module)
+
+
+def _with_verbose_v1_operands(module: SerializationModule) -> SerializationModule:
+    module = copy.deepcopy(module)
+    definitions = {
+        unit.data["id"]: unit
+        for unit in _walk_units(module.body)
+        if unit.kind in ("block-arg", "result-value")
+    }
+
+    for statement in (
+        unit for unit in _walk_units(module.body) if unit.kind == "statement"
+    ):
+        operands = statement.data["_args"].data["value"]
+        statement.data["_args"].data["value"] = [
+            copy.deepcopy(definitions[operand.data["id"]]) for operand in operands
+        ]
+    return module
+
+
+def _to_verbose_v1(value: Any) -> Any:
+    if isinstance(value, SerializationModule):
+        return {
+            "__serialization_module__": True,
+            "version": value.version,
+            "symbol_table": _to_verbose_v1(value.symbol_table),
+            "body": _to_verbose_v1(value.body),
+        }
+    if isinstance(value, SerializationUnit):
+        return {
+            "__serialization_unit__": True,
+            "kind": value.kind,
+            "module_name": value.module_name,
+            "class_name": value.class_name,
+            "data": _to_verbose_v1(value.data),
+        }
+    if isinstance(value, dict):
+        return {key: _to_verbose_v1(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_verbose_v1(item) for item in value]
+    return value
+
+
+@pytest.mark.parametrize("transport", ["json", "cbson"])
+def test_verbose_v1_full_ssa_operands_remain_readable(transport: str) -> None:
+    old_module = _with_verbose_v1_operands(branching.dialects.encode(branching))
+    verbose = _to_verbose_v1(old_module)
+
+    if transport == "json":
+        module = JSONSerializer().decode(json.dumps(verbose))
+    else:
+        payload = gzip.compress(bson.encode(verbose), mtime=0)
+        module = CompressedBSONSerializer().decode(payload)
+
+    operand_kinds = {
+        operand.kind
+        for statement in _walk_units(module.body)
+        if statement.kind == "statement"
+        for operand in statement.data["_args"].data["value"]
+    }
+    assert operand_kinds <= {"block-arg", "result-value"}
+    assert operand_kinds == {"block-arg", "result-value"}
+
+    decoded = branching.dialects.decode(module)
+    _assert_exact_reverse_uses(decoded)
+    decoded.verify()
+    assert decoded(3, True) == branching(3, True)
+    assert decoded(3, False) == branching(3, False)

--- a/test/serialization/test_type_attribute_refs.py
+++ b/test/serialization/test_type_attribute_refs.py
@@ -1,0 +1,331 @@
+"""Identity-reference tests for repeated TypeAttribute metadata."""
+
+from __future__ import annotations
+
+import copy
+import gzip
+import json
+from typing import Any, Literal
+from collections.abc import Iterator
+
+import bson
+import pytest
+
+from kirin import ir, types
+from kirin.prelude import basic_no_opt
+from kirin.serialization.bsonserializer import CompressedBSONSerializer
+from kirin.serialization.jsonserializer import JSONSerializer
+from kirin.serialization.base.serializer import Serializer
+from kirin.serialization.base.deserializer import Deserializer
+from kirin.serialization.core.serializationunit import SerializationUnit
+from kirin.serialization.core.serializationmodule import SerializationModule
+
+
+@basic_no_opt
+def passthrough(x: int) -> int:
+    return x
+
+
+Transport = Literal["module", "json", "cbson"]
+TRANSPORTS: tuple[Transport, ...] = ("module", "json", "cbson")
+
+
+def _method_with_fields(*fields: object) -> ir.Method:
+    method = passthrough.similar()
+    method.fields = fields
+    return method
+
+
+def _field_units(module: SerializationModule) -> list[SerializationUnit]:
+    fields = module.body.data["fields"]
+    assert isinstance(fields, SerializationUnit)
+    assert fields.kind == "tuple"
+    return fields.data["value"]
+
+
+def _through_transport(
+    module: SerializationModule, transport: Transport
+) -> SerializationModule:
+    if transport == "module":
+        return module
+    if transport == "json":
+        codec = JSONSerializer()
+        return codec.decode(codec.encode(module))
+
+    codec = CompressedBSONSerializer()
+    return codec.decode(codec.encode(module))
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_repeated_type_attribute_uses_one_definition_and_preserves_v1_isolation(
+    transport: Transport,
+) -> None:
+    shared = types.TypeVar("Shared")
+    method = _method_with_fields(shared, shared)
+
+    module = method.dialects.encode(method, version="caller-version")
+    first, second = _field_units(module)
+
+    assert first.kind == "attribute"
+    assert set(first.data) == {"data", "id"}
+    assert first.data["data"].kind == "type-attribute"
+    assert second.kind == "attr_ref"
+    assert second.module_name == ""
+    assert second.class_name == ""
+    assert second.data == {"id": first.data["id"]}
+    assert module.version == "caller-version"
+
+    transported = _through_transport(module, transport)
+    decoded = method.dialects.decode(transported)
+
+    first_decoded, second_decoded = decoded.fields
+    assert first_decoded is not second_decoded
+    assert first_decoded == second_decoded
+    assert isinstance(first_decoded, types.TypeVar)
+
+    new_bound = types.TypeVar("NewBound")
+    first_decoded.bound = new_bound
+    assert second_decoded.bound is not new_bound
+    assert decoded(7) == 7
+
+
+def test_unique_type_attribute_has_no_reference_metadata() -> None:
+    unique = types.TypeVar("Unique")
+    method = _method_with_fields(unique)
+
+    module = method.dialects.encode(method)
+    (field,) = _field_units(module)
+
+    assert field.kind == "attribute"
+    assert set(field.data) == {"data"}
+
+
+def test_standalone_attribute_serialization_uses_a_reference() -> None:
+    shared = types.TypeVar("Standalone")
+    serializer = Serializer()
+
+    first = serializer.serialize_attribute(shared)
+    second = serializer.serialize_attribute(shared)
+
+    assert first.kind == "attribute"
+    assert set(first.data) == {"data", "id"}
+    assert second.kind == "attr_ref"
+    assert second.data == {"id": first.data["id"]}
+
+    deserializer = Deserializer(passthrough.dialects)
+    first_decoded = deserializer.deserialize(first)
+    second_decoded = deserializer.deserialize(second)
+    assert first_decoded is not second_decoded
+    assert first_decoded == second_decoded
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_distinct_but_equal_type_attributes_are_not_interned(
+    transport: Transport,
+) -> None:
+    first = types.TypeVar("T")
+    second = types.TypeVar("T")
+    assert first is not second
+    assert first == second
+    method = _method_with_fields(first, second)
+
+    module = method.dialects.encode(method)
+    first_unit, second_unit = _field_units(module)
+
+    assert first_unit.kind == second_unit.kind == "attribute"
+    assert "id" not in first_unit.data
+    assert "id" not in second_unit.data
+
+    decoded = method.dialects.decode(_through_transport(module, transport))
+    assert decoded.fields[0] is not decoded.fields[1]
+    assert decoded.fields[0] == decoded.fields[1]
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_general_pyattr_is_not_memoized(transport: Transport) -> None:
+    shared_type = types.TypeVar("PayloadType")
+    wrapper = ir.PyAttr(7, pytype=shared_type)
+    method = _method_with_fields(wrapper, wrapper)
+
+    module = method.dialects.encode(method)
+    first, second = _field_units(module)
+
+    assert first.kind == second.kind == "attribute"
+    assert set(first.data) == set(second.data) == {"data"}
+    assert first.data["data"].kind == second.data["data"].kind == "pyattr"
+
+    decoded = method.dialects.decode(_through_transport(module, transport))
+    assert decoded.fields[0] is not decoded.fields[1]
+    assert decoded.fields[0].type is not decoded.fields[1].type
+    assert decoded.fields[0].type == decoded.fields[1].type
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_forward_ref_from_reversed_pyattr_field_order(transport: Transport) -> None:
+    shared = types.TypeVar("Reversed")
+    wrapper = ir.PyAttr(shared, pytype=shared)
+    method = _method_with_fields(wrapper)
+
+    module = method.dialects.encode(method)
+    (field,) = _field_units(module)
+    pyattr = field.data["data"]
+    definition = pyattr.data["data"]
+    reference = pyattr.data["pytype"]
+
+    assert definition.kind == "attribute"
+    assert reference.kind == "attr_ref"
+    assert reference.data["id"] == definition.data["id"]
+
+    decoded = method.dialects.decode(_through_transport(module, transport))
+    decoded_wrapper = decoded.fields[0]
+    assert decoded_wrapper.type is not decoded_wrapper.data
+    assert decoded_wrapper.type == decoded_wrapper.data
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_nested_type_graph_preserves_v1_value_semantics(
+    transport: Transport,
+) -> None:
+    leaf = types.TypeVar("Leaf")
+    literal = types.Literal(1, leaf)
+    union = types.Union(literal, types.String)
+    generic = types.Generic(tuple, leaf, types.Vararg(leaf))
+    method = _method_with_fields(union, union, generic, generic)
+
+    module = method.dialects.encode(method)
+    decoded = method.dialects.decode(_through_transport(module, transport))
+    decoded_union = decoded.fields[0]
+    decoded_generic = decoded.fields[2]
+
+    assert decoded_union is not decoded.fields[1]
+    assert decoded_union == decoded.fields[1]
+    decoded_literal = next(
+        attr for attr in decoded_union.types if isinstance(attr, types.Literal)
+    )
+
+    assert decoded_generic is not decoded.fields[3]
+    assert decoded_generic == decoded.fields[3]
+    assert decoded_literal.is_structurally_equal(literal)
+    assert decoded_generic.vars[0] is not decoded_generic.vararg.typ
+    assert decoded_generic.vars[0] == decoded_generic.vararg.typ
+
+
+@pytest.mark.parametrize("transport_name", ["json", "cbson"])
+def test_attr_ref_uses_short_compact_wire_shape(transport_name: str) -> None:
+    shared = types.TypeVar("Compact")
+    method = _method_with_fields(shared, shared)
+    module = method.dialects.encode(method)
+
+    if transport_name == "json":
+        wire = json.loads(JSONSerializer().encode(module))
+    else:
+        payload = CompressedBSONSerializer().encode(module)
+        wire = bson.decode(gzip.decompress(payload))
+
+    compact_refs = [
+        mapping["$u"]
+        for mapping in _walk_wire_mappings(wire)
+        if len(mapping) == 1 and "$u" in mapping and mapping["$u"][0] == "attr_ref"
+    ]
+    assert compact_refs
+    assert all(len(payload) == 2 for payload in compact_refs)
+
+
+def _walk_wire_mappings(value: Any) -> Iterator[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from _walk_wire_mappings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_wire_mappings(item)
+
+
+def test_type_attribute_definitions_without_ids_still_decode() -> None:
+    first = types.TypeVar("Legacy")
+    second = types.TypeVar("Legacy")
+    method = _method_with_fields(first, second)
+    serializer = Serializer()
+    body = serializer.serialize_method(method)
+    module = SerializationModule(
+        symbol_table=dict(serializer._ctx.Method_Symbol),
+        body=body,
+        version="legacy-version",
+    )
+
+    fields = _field_units(module)
+    assert all(field.kind == "attribute" for field in fields)
+    assert all(set(field.data) == {"data"} for field in fields)
+
+    decoded = method.dialects.decode(module)
+    assert decoded.fields[0] == decoded.fields[1]
+    assert decoded(3) == 3
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        pytest.param({}, r"attr_ref is missing required 'id'", id="missing-id"),
+        pytest.param(
+            {"id": 17}, r"attr_ref id must be a string, got 17", id="non-string-id"
+        ),
+    ],
+)
+def test_malformed_attr_ref_ids_fail_contextually(
+    data: dict[str, object], message: str
+) -> None:
+    unit = SerializationUnit("attr_ref", "", "", data)
+    deserializer = Deserializer(passthrough.dialects)
+
+    with pytest.raises(ValueError, match=message):
+        deserializer.deserialize(unit)
+
+
+def test_attr_ref_data_must_be_a_mapping() -> None:
+    unit = SerializationUnit("attr_ref", "", "", [])  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="attr_ref data must be a mapping"):
+        Deserializer(passthrough.dialects).deserialize(unit)
+
+
+def test_dangling_attr_ref_fails_contextually() -> None:
+    shared = types.TypeVar("Dangling")
+    method = _method_with_fields(shared, shared)
+    module = method.dialects.encode(method)
+    _, reference = _field_units(module)
+    reference.data["id"] = "not-defined"
+
+    with pytest.raises(ValueError, match=r"dangling attr_ref 'not-defined'"):
+        method.dialects.decode(module)
+
+
+def test_duplicate_type_attribute_definition_id_is_rejected() -> None:
+    shared = types.TypeVar("Duplicate")
+    method = _method_with_fields(shared, shared)
+    module = method.dialects.encode(method)
+    fields = _field_units(module)
+    fields[1] = copy.deepcopy(fields[0])
+
+    with pytest.raises(
+        ValueError, match=r"duplicate TypeAttribute definition id 't[0-9]+'"
+    ):
+        method.dialects.decode(module)
+
+
+def test_attr_ref_to_general_attribute_is_rejected() -> None:
+    shared = types.TypeVar("WrongKind")
+    method = _method_with_fields(shared, shared)
+    module = method.dialects.encode(method)
+    definition, reference = _field_units(module)
+    attr_id = definition.data["id"]
+
+    wrong_definition = Serializer().serialize_attribute(ir.PyAttr(1))
+    wrong_definition.data["id"] = attr_id
+    fields = _field_units(module)
+    fields[:] = [reference, wrong_definition]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"TypeAttribute definition {attr_id!r} decoded as PyAttr",
+    ):
+        method.dialects.decode(module)


### PR DESCRIPTION
### Problem
Serialization had redundant metadata. ~76% of every payload is envelope metadata (`__serialization_unit__,` `module_name`, `class_name`; all derivable from kind for core types), SSA values are re-serialized in full at every use site, and repeated type attributes are written out once per mention.
### Changes

1. Compact wire codec.  Units serialize as `{"$u": [kind, data]}`, with `module_name/class_name` elided only when the pair matches a reviewed static table; everything else keeps its full descriptor. `{"$m": [...]} `escapes user mappings that would otherwise resemble a control tag.
2. SSA operand references.  A value's full record is written once at its owner position (`block._args`, `stmt._results`); operands are `ssa_ref` units resolved through the decoder's existing `SSA_Lookup`.
3. `TypeAttribute` identity references. Repeated `TypeAttribute` identities emit one definition plus `attr_ref` units. `PyAttr` and other general attributes are unchanged.

### Rsults


|  | JSON size | gzip'd BSON size | JSON round trip | gzip'd BSON round trip |
|---|---:|---:|---:|---:|
| **mean across test kernels** | **−76.7%** | **−24.1%** | **29.6% faster** | **8.4% faster** |
