### PR TITLE
Optimize shared-method serialization with method references

### DIFF
--- a/src/kirin/ir/attrs/py.py
+++ b/src/kirin/ir/attrs/py.py
@@ -100,8 +100,8 @@ class PyAttr(Data[T]):
     def deserialize(
         cls: Type["PyAttr"], serUnit: "SerializationUnit", deserializer: "Deserializer"
     ) -> "PyAttr":
-        pytype = deserializer.deserialize(serUnit.data["pytype"])
         value = deserializer.deserialize(serUnit.data["data"])
+        pytype = deserializer.deserialize(serUnit.data["pytype"])
         return PyAttr(value, pytype=pytype)
 
 

--- a/src/kirin/serialization/base/context.py
+++ b/src/kirin/serialization/base/context.py
@@ -1,19 +1,9 @@
-from typing import List, TypedDict
 from importlib import import_module
 from dataclasses import field, dataclass
 
 from kirin import ir, types
 from kirin.idtable import IdTable
 from kirin.serialization.core.serializationunit import SerializationUnit
-
-PREFIX = "_method_@"
-PARAM_SEP = "->"
-
-
-class MethodSymbolMeta(TypedDict, total=False):
-    sym_name: str
-    arg_types: List[str]
-    ret_type: str
 
 
 @dataclass
@@ -31,6 +21,9 @@ class SerializationContext:
     type_attribute_idtable: IdTable[int] = field(
         default_factory=lambda: IdTable[int](prefix="t")
     )
+    method_idtable: IdTable[int] = field(
+        default_factory=lambda: IdTable[int](prefix="m")
+    )
 
     Dialect_Lookup: dict[str, ir.Dialect] = field(default_factory=dict)
     SSA_Lookup: dict[str, ir.SSAValue] = field(default_factory=dict)
@@ -38,9 +31,7 @@ class SerializationContext:
     Statement_Lookup: dict[str, ir.Statement] = field(default_factory=dict)
     Block_Lookup: dict[str, ir.Block] = field(default_factory=dict)
     Region_Lookup: dict[str, ir.Region] = field(default_factory=dict)
-
-    Method_Symbol: dict[str, MethodSymbolMeta] = field(default_factory=dict)
-    Method_Runtime: dict[str, ir.Method] = field(default_factory=dict)
+    Method_Lookup: dict[str, ir.Method] = field(default_factory=dict)
 
     type_attribute_entries: dict[int, TypeAttributeSerializationEntry] = field(
         default_factory=dict
@@ -48,8 +39,6 @@ class SerializationContext:
     TypeAttribute_Definitions: dict[str, SerializationUnit] = field(
         default_factory=dict
     )
-    _type_attribute_root: SerializationUnit | None = None
-    _type_attribute_indexed: bool = False
 
     _block_reference_store: dict[str, ir.Block] = field(
         default_factory=dict[str, ir.Block]
@@ -61,39 +50,17 @@ class SerializationContext:
         self.Block_Lookup.clear()
         self.Region_Lookup.clear()
         self.Statement_Lookup.clear()
+        self.Method_Lookup.clear()
         self.ssa_idtable.clear()
         self.stmt_idtable.clear()
         self.blk_idtable.clear()
         self.region_idtable.clear()
         self.type_attribute_idtable.clear()
+        self.method_idtable.clear()
         self._block_reference_store.clear()
-        self.Method_Symbol.clear()
-        self.Method_Runtime.clear()
         self.Dialect_Lookup.clear()
         self.type_attribute_entries.clear()
         self.TypeAttribute_Definitions.clear()
-        self._type_attribute_root = None
-        self._type_attribute_indexed = False
-
-
-def get_str_from_type(typ: types.TypeAttribute) -> str:
-    if isinstance(typ, types.PyClass):
-        return typ.typ.__name__
-    return "None"
-
-
-def mangle(
-    symbol_name: str | None,
-    param_types: tuple[types.TypeAttribute, ...],
-    output: types.TypeAttribute | None = None,
-) -> str:
-    mangled_name = f"{PREFIX}{symbol_name}"
-    if param_types:
-        for typ in param_types:
-            mangled_name += f"{PARAM_SEP}{get_str_from_type(typ)}"
-    if output is not None:
-        mangled_name += f"{PARAM_SEP}{get_str_from_type(output)}"
-    return mangled_name
 
 
 def get_cls_from_name(serUnit: SerializationUnit) -> type:

--- a/src/kirin/serialization/base/deserializer.py
+++ b/src/kirin/serialization/base/deserializer.py
@@ -4,14 +4,18 @@ from dataclasses import field, dataclass
 
 from kirin import ir, types
 from kirin.serialization.base.context import (
-    MethodSymbolMeta,
     SerializationContext,
-    mangle,
     get_cls_from_name,
 )
 from kirin.serialization.core.deserializable import Deserializable
 from kirin.serialization.core.serializationunit import SerializationUnit
 from kirin.serialization.core.serializationmodule import SerializationModule
+
+_DANGLING_REF_CAUSES = (
+    "no definition has been decoded for it. Either the payload contains no "
+    "definition for this reference, or a serialize/deserialize pair does not "
+    "decode the fields in the order it encodes them."
+)
 
 
 @dataclass
@@ -21,28 +25,16 @@ class Deserializer:
 
     def decode(self, data: SerializationModule) -> ir.Method:
         self._ctx.clear()
-        for mangled, meta in data.symbol_table.items():
-            sym_name = meta.get("sym_name", None)
-            if sym_name is None:
-                raise ValueError(f"symbol_table[{mangled}] missing 'sym_name'")
-            arg_types = meta.get("arg_types", []) or []
-            self._ctx.Method_Symbol[mangled] = MethodSymbolMeta(
-                sym_name=sym_name,
-                arg_types=list(arg_types),
-            )
-
         body = data.body
         if body is None:
             raise ValueError("Module envelope missing body for decoding.")
-        self._ctx._type_attribute_root = body
-        try:
-            return self.deserialize_method(body)
-        finally:
-            self._ctx._type_attribute_root = None
+        return self.deserialize_method(body)
 
     def deserialize(self, serUnit: SerializationUnit) -> Any:
         if serUnit.kind == "ssa_ref":
             return self.deserialize_ssa_ref(serUnit)
+        elif serUnit.kind == "method_ref":
+            return self.deserialize_method_ref(serUnit)
         elif serUnit.kind == "attr_ref":
             return self.deserialize_attr_ref(serUnit)
         elif serUnit.kind == "attribute":
@@ -82,55 +74,7 @@ class Deserializer:
         if existing is not None:
             return existing
 
-        definition = self._ctx.TypeAttribute_Definitions.get(attr_id)
-        if definition is None:
-            self._index_type_attribute_definitions()
-            try:
-                definition = self._ctx.TypeAttribute_Definitions[attr_id]
-            except KeyError:
-                raise ValueError(f"dangling attr_ref {attr_id!r}") from None
-        return self._deserialize_type_attribute_definition(definition, attr_id)
-
-    def _index_type_attribute_definitions(self) -> None:
-        if self._ctx._type_attribute_indexed:
-            return
-        if self._ctx._type_attribute_root is None:
-            raise ValueError("cannot resolve attr_ref outside Method decoding")
-
-        seen: set[int] = set()
-
-        def visit(value: Any) -> None:
-            if isinstance(value, SerializationUnit):
-                identity = id(value)
-                if identity in seen:
-                    return
-                seen.add(identity)
-
-                if value.kind == "attribute":
-                    if not isinstance(value.data, dict):
-                        raise ValueError("Attribute data must be a mapping")
-                    if "id" in value.data:
-                        attr_id = value.data["id"]
-                        if not isinstance(attr_id, str):
-                            raise ValueError(
-                                f"TypeAttribute definition id must be a string, got {attr_id!r}"
-                            )
-                        existing = self._ctx.TypeAttribute_Definitions.get(attr_id)
-                        if existing is not None and existing is not value:
-                            raise ValueError(
-                                f"duplicate TypeAttribute definition id {attr_id!r}"
-                            )
-                        self._ctx.TypeAttribute_Definitions[attr_id] = value
-                visit(value.data)
-            elif isinstance(value, dict):
-                for item in value.values():
-                    visit(item)
-            elif isinstance(value, (list, tuple)):
-                for item in value:
-                    visit(item)
-
-        visit(self._ctx._type_attribute_root)
-        self._ctx._type_attribute_indexed = True
+        raise ValueError(f"dangling attr_ref {attr_id!r}: {_DANGLING_REF_CAUSES}")
 
     def generic_deserialize(self, data: SerializationUnit) -> Any:
         if not hasattr(data, "kind"):
@@ -177,20 +121,43 @@ class Deserializer:
                         f"Unsupported kind {data.kind} for deserialization."
                     )
 
-    def deserialize_method(self, serUnit: SerializationUnit) -> ir.Method:
-        mangled = serUnit.data.get("mangled")
-        if mangled is None:
-            raise ValueError("Missing 'mangled' key for method deserialization.")
+    def deserialize_method_ref(self, serUnit: SerializationUnit) -> ir.Method:
+        if not isinstance(serUnit.data, dict):
+            raise ValueError("method_ref data must be a mapping")
+        try:
+            method_id = serUnit.data["id"]
+        except KeyError:
+            raise ValueError("method_ref is missing required 'id'") from None
+        if not isinstance(method_id, str):
+            raise ValueError(f"method_ref id must be a string, got {method_id!r}")
+        try:
+            return self._ctx.Method_Lookup[method_id]
+        except KeyError:
+            raise ValueError(
+                f"dangling method_ref {method_id!r}: {_DANGLING_REF_CAUSES}"
+            ) from None
 
-        out = self._ctx.Method_Runtime.get(mangled)
-        if out is None:
-            out = ir.Method.__new__(ir.Method)
-            out.mod = None
-            out.py_func = None
-            out.code = ir.Statement.__new__(ir.Statement)
-            out.backedges = weakref.WeakSet()
-            out.run_passes = None
-            self._ctx.Method_Runtime[mangled] = out
+    def deserialize_method(self, serUnit: SerializationUnit) -> ir.Method:
+        try:
+            method_id = serUnit.data["id"]
+        except KeyError:
+            raise ValueError(
+                "method unit is missing required 'id'; payloads written before "
+                "method identity references are not supported"
+            ) from None
+
+        existing = self._ctx.Method_Lookup.get(method_id)
+        if existing is not None:
+            return existing
+
+        out = ir.Method.__new__(ir.Method)
+        out.mod = None
+        out.py_func = None
+        out.code = ir.Statement.__new__(ir.Statement)
+        out.backedges = weakref.WeakSet()
+        out.run_passes = None
+
+        self._ctx.Method_Lookup[method_id] = out
 
         out.sym_name = serUnit.data["sym_name"]
         out.arg_names = serUnit.data.get("arg_names", [])
@@ -207,17 +174,7 @@ class Deserializer:
         out.dialects = self.dialect_group
 
         out.code = self.deserialize_statement(serUnit.data["code"])
-        out.backedges = weakref.WeakSet()
         out.fields = self.deserialize_tuple(serUnit.data.get("fields", ()))
-        computed = mangle(
-            out.sym_name,
-            getattr(out, "arg_types", ()),
-            getattr(out, "ret_type", None),
-        )
-        if computed != mangled:
-            raise ValueError(
-                f"Mangled name mismatch: expected {mangled}, got {computed}"
-            )
         out.update_backedges()
         return out
 

--- a/src/kirin/serialization/base/serializer.py
+++ b/src/kirin/serialization/base/serializer.py
@@ -2,11 +2,8 @@ from dataclasses import field, dataclass
 
 from kirin import ir, types
 from kirin.serialization.base.context import (
-    MethodSymbolMeta,
     SerializationContext,
     TypeAttributeSerializationEntry,
-    mangle,
-    get_str_from_type,
 )
 from kirin.serialization.core.serializable import Serializable
 from kirin.serialization.core.supportedtypes import SUPPORTED_PYTHON_TYPES
@@ -20,27 +17,7 @@ class Serializer:
 
     def encode(self, obj: ir.Method, version: str = "") -> SerializationModule:
         self._ctx.clear()
-        body = self.serialize_method(obj)
-        if getattr(self._ctx, "Method_Symbol", None):
-            st: dict[str, MethodSymbolMeta] = {}
-            for mangled, meta in self._ctx.Method_Symbol.items():
-                sym_name = meta.get("sym_name")
-                if sym_name is None:
-                    raise ValueError(f"symbol_table[{mangled}] missing 'sym_name'")
-                st[mangled] = (
-                    MethodSymbolMeta(
-                        sym_name=sym_name,
-                        arg_types=meta.get("arg_types", []),
-                    )
-                    if isinstance(meta, dict)
-                    else meta
-                )
-            symbol_table: dict[str, MethodSymbolMeta] = st
-        else:
-            symbol_table = dict[str, MethodSymbolMeta]()
-        return SerializationModule(
-            symbol_table=symbol_table, body=body, version=version
-        )
+        return SerializationModule(body=self.serialize_method(obj), version=version)
 
     def serialize(
         self,
@@ -103,33 +80,16 @@ class Serializer:
             )
 
     def serialize_method(self, mthd: ir.Method) -> SerializationUnit:
-        mangled = mangle(
-            mthd.sym_name,
-            getattr(mthd, "arg_types", ()),
-            getattr(mthd, "ret_type", None),
-        )
-        arg_types_list: list[str] = []
-        ret_type: str = get_str_from_type(mthd.return_type)
-        for t in getattr(mthd, "arg_types", ()):
-            arg_types_list.append(get_str_from_type(t))
         if mthd.sym_name is None:
             raise ValueError("Method.sym_name is None, cannot serialize.")
-        meta: MethodSymbolMeta = {
-            "sym_name": mthd.sym_name,
-            "arg_types": arg_types_list,
-            "ret_type": ret_type,
-        }
 
-        existing = self._ctx.Method_Symbol.get(mangled)
-        if existing is not None:
-            if existing != meta:
-                raise ValueError(
-                    f"Mangled name collision for {mangled}: existing={existing} new={meta}"
-                )
-        else:
-            self._ctx.Method_Symbol[mangled] = meta
+        method_id = self._ctx.method_idtable[id(mthd)]
+        if method_id in self._ctx.Method_Lookup:
+            return self.serialize_method_ref(mthd)
 
-        out = SerializationUnit(
+        self._ctx.Method_Lookup[method_id] = mthd
+
+        return SerializationUnit(
             kind="method",
             module_name=ir.Method.__module__,
             class_name=ir.Method.__name__,
@@ -140,10 +100,22 @@ class Serializer:
                 "code": self.serialize_statement(mthd.code),
                 "nargs": self.serialize_int(mthd.nargs),
                 "fields": self.serialize_tuple(mthd.fields),
-                "mangled": mangled,
+                "id": method_id,
             },
         )
-        return out
+
+    def serialize_method_ref(self, mthd: ir.Method) -> SerializationUnit:
+        method_id = self._ctx.method_idtable[id(mthd)]
+        if method_id not in self._ctx.Method_Lookup:
+            raise ValueError(
+                f"Cannot reference method {mthd.sym_name!r} before its definition"
+            )
+        return SerializationUnit(
+            kind="method_ref",
+            module_name="",
+            class_name="",
+            data={"id": method_id},
+        )
 
     def serialize_statement(self, stmt: ir.Statement) -> SerializationUnit:
         return SerializationUnit(

--- a/src/kirin/serialization/core/serializationmodule.py
+++ b/src/kirin/serialization/core/serializationmodule.py
@@ -1,22 +1,18 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from kirin.serialization.base.context import MethodSymbolMeta
     from kirin.serialization.core.serializationunit import SerializationUnit
 
 
 class SerializationModule:
-    symbol_table: dict[str, "MethodSymbolMeta"]
     body: "SerializationUnit"
     version: str
 
     def __init__(
         self,
-        symbol_table: dict[str, "MethodSymbolMeta"],
         body: "SerializationUnit",
         version: str = "",
     ):
-        self.symbol_table = symbol_table
         self.body = body
         self.version = version
 

--- a/src/kirin/serialization/jsonserializer.py
+++ b/src/kirin/serialization/jsonserializer.py
@@ -26,6 +26,7 @@ STATIC_DESCRIPTORS: dict[str, tuple[str, str]] = {
     "int": ("builtins", "int"),
     "list": ("builtins", "list"),
     "method": ("kirin.ir.method", "Method"),
+    "method_ref": ("", ""),
     "none": ("builtins", "NoneType"),
     "range": ("builtins", "range"),
     "region": ("kirin.ir.nodes.region", "Region"),
@@ -50,7 +51,6 @@ class JSONtifiable:
             return {
                 "__serialization_module__": True,
                 "version": obj.version,
-                "symbol_table": self._to_jsonifiable(obj.symbol_table),
                 "body": self._to_jsonifiable(obj.body),
             }
         if isinstance(obj, SerializationUnit):
@@ -80,17 +80,11 @@ class JSONtifiable:
                     raw_body.get("__serialization_unit__")
                 )
                 child_allow_compact_tags = allow_compact_tags and not is_verbose
-                symbol_table = self._from_jsonifiable(
-                    obj.get("symbol_table", {}),
-                    allow_compact_tags=child_allow_compact_tags,
-                )
                 body = self._from_jsonifiable(
                     raw_body, allow_compact_tags=child_allow_compact_tags
                 )
                 version = obj.get("version", "")
-                return SerializationModule(
-                    symbol_table=symbol_table, body=body, version=version
-                )
+                return SerializationModule(body=body, version=version)
             if obj.get("__serialization_unit__"):
                 data = self._from_jsonifiable(
                     obj.get("data", {}), allow_compact_tags=False

--- a/test/serialization/test_compact_codec.py
+++ b/test/serialization/test_compact_codec.py
@@ -40,7 +40,7 @@ def transport(request: pytest.FixtureRequest) -> Transport:
 
 
 def _module(body: SerializationUnit, *, version: str = "") -> SerializationModule:
-    return SerializationModule(symbol_table={}, body=body, version=version)
+    return SerializationModule(body=body, version=version)
 
 
 def _assert_unit_equal(actual: SerializationUnit, expected: SerializationUnit) -> None:
@@ -345,7 +345,6 @@ VERBOSE_INT = {
 VERBOSE_MODULE = {
     "__serialization_module__": True,
     "version": "caller-version",
-    "symbol_table": {},
     "body": {
         "__serialization_unit__": True,
         "kind": "list",
@@ -362,7 +361,6 @@ VERBOSE_CONTROL_TAG_DATA = {
 VERBOSE_CONTROL_TAG_MODULE = {
     "__serialization_module__": True,
     "version": "caller-version",
-    "symbol_table": {},
     "body": {
         "__serialization_unit__": True,
         "kind": "custom",

--- a/test/serialization/test_method_refs.py
+++ b/test/serialization/test_method_refs.py
@@ -1,0 +1,92 @@
+"""Method-reference coverage for an ``animate_ghz``-shaped call graph.
+
+The animation wrapper calls one compiled kernel. Inside that compiled kernel,
+multiple call sites can reference the same move kernel. The serializer should
+emit that shared method once and use ``method_ref`` thereafter.
+"""
+
+from typing import Any
+from collections.abc import Iterator
+
+from kirin import ir
+from kirin.prelude import basic
+from kirin.dialects import func
+from kirin.serialization.jsonserializer import JSONSerializer
+from kirin.serialization.base.serializer import Serializer
+from kirin.serialization.core.serializationunit import SerializationUnit
+
+
+@basic
+def move_kernel(x: int) -> int:
+    return x * 2
+
+
+@basic
+def compiled_kernel(x: int) -> int:
+    return move_kernel(x) + move_kernel(x + 1) + move_kernel(x + 2)
+
+
+@basic
+def animation_kernel(x: int) -> int:
+    return compiled_kernel(x)
+
+
+def _walk_units(value: Any) -> Iterator[SerializationUnit]:
+    if isinstance(value, SerializationUnit):
+        yield value
+        yield from _walk_units(value.data)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _walk_units(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _walk_units(item)
+
+
+def _invoke_callees(method: ir.Method) -> list[ir.Method]:
+    return [stmt.callee for stmt in method.code.walk() if isinstance(stmt, func.Invoke)]
+
+
+def test_multiple_call_sites_emit_method_refs() -> None:
+    module = Serializer().encode(animation_kernel)
+    units = tuple(_walk_units(module.body))
+
+    definitions = [unit for unit in units if unit.kind == "method"]
+    references = [unit for unit in units if unit.kind == "method_ref"]
+    move_definition = next(
+        unit for unit in definitions if unit.data["sym_name"] == "move_kernel"
+    )
+
+    assert len(definitions) == 3  # wrapper, compiled kernel, shared move kernel
+    assert len(references) == 2
+    assert {ref.data["id"] for ref in references} == {move_definition.data["id"]}
+
+
+def test_multiple_call_sites_round_trip_with_shared_identity() -> None:
+    codec = JSONSerializer()
+    module = codec.decode(codec.encode(Serializer().encode(animation_kernel)))
+    decoded = animation_kernel.dialects.decode(module)
+
+    (decoded_compiled_kernel,) = _invoke_callees(decoded)
+    move_callees = _invoke_callees(decoded_compiled_kernel)
+
+    decoded.verify()
+    assert len(move_callees) == 3
+    assert len({id(callee) for callee in move_callees}) == 1
+    assert decoded(4) == animation_kernel(4)
+
+
+def test_region_parent_node_survives_call_sites() -> None:
+    """Each duplicate used to build its own ``func.Function`` while the shared
+    region kept the first one as ``parent_node``. ``Method.code`` ended up as the
+    last, so the region pointed at a discarded statement -- and ``verify()``
+    passed anyway.
+    """
+    codec = JSONSerializer()
+    module = codec.decode(codec.encode(Serializer().encode(animation_kernel)))
+    decoded = animation_kernel.dialects.decode(module)
+
+    (decoded_compiled_kernel,) = _invoke_callees(decoded)
+    move_callee = _invoke_callees(decoded_compiled_kernel)[0]
+
+    assert move_callee.code.regions[0].parent_node is move_callee.code

--- a/test/serialization/test_ssa_refs.py
+++ b/test/serialization/test_ssa_refs.py
@@ -367,7 +367,6 @@ def _to_verbose_v1(value: Any) -> Any:
         return {
             "__serialization_module__": True,
             "version": value.version,
-            "symbol_table": _to_verbose_v1(value.symbol_table),
             "body": _to_verbose_v1(value.body),
         }
     if isinstance(value, SerializationUnit):

--- a/test/serialization/test_type_attribute_refs.py
+++ b/test/serialization/test_type_attribute_refs.py
@@ -160,28 +160,6 @@ def test_general_pyattr_is_not_memoized(transport: Transport) -> None:
 
 
 @pytest.mark.parametrize("transport", TRANSPORTS)
-def test_forward_ref_from_reversed_pyattr_field_order(transport: Transport) -> None:
-    shared = types.TypeVar("Reversed")
-    wrapper = ir.PyAttr(shared, pytype=shared)
-    method = _method_with_fields(wrapper)
-
-    module = method.dialects.encode(method)
-    (field,) = _field_units(module)
-    pyattr = field.data["data"]
-    definition = pyattr.data["data"]
-    reference = pyattr.data["pytype"]
-
-    assert definition.kind == "attribute"
-    assert reference.kind == "attr_ref"
-    assert reference.data["id"] == definition.data["id"]
-
-    decoded = method.dialects.decode(_through_transport(module, transport))
-    decoded_wrapper = decoded.fields[0]
-    assert decoded_wrapper.type is decoded_wrapper.data
-    assert decoded_wrapper.type == decoded_wrapper.data
-
-
-@pytest.mark.parametrize("transport", TRANSPORTS)
 def test_nested_type_graph_preserves_identity_relationships(
     transport: Transport,
 ) -> None:
@@ -309,7 +287,6 @@ def test_type_attribute_definitions_without_ids_still_decode() -> None:
     serializer = Serializer()
     body = serializer.serialize_method(method)
     module = SerializationModule(
-        symbol_table=dict(serializer._ctx.Method_Symbol),
         body=body,
         version="legacy-version",
     )
@@ -383,10 +360,44 @@ def test_attr_ref_to_general_attribute_is_rejected() -> None:
     wrong_definition = Serializer().serialize_attribute(ir.PyAttr(1))
     wrong_definition.data["id"] = attr_id
     fields = _field_units(module)
-    fields[:] = [reference, wrong_definition]
+    # definition first, so the payload is well ordered and the *kind* check is
+    # what must reject it. The out-of-order case is
+    # `test_attr_ref_before_its_definition_fails_loudly`.
+    fields[:] = [wrong_definition, reference]
 
     with pytest.raises(
         ValueError,
         match=rf"TypeAttribute definition {attr_id!r} decoded as PyAttr",
     ):
         method.dialects.decode(module)
+
+
+@pytest.mark.parametrize("transport", TRANSPORTS)
+def test_attr_ref_before_its_definition_fails_loudly(transport: Transport) -> None:
+    """A reference read before its definition is an error, not something to repair.
+
+    The decoder used to rescan the whole payload to locate a definition it had
+    not reached yet. That fallback existed for one reason: `PyAttr.serialize`
+    wrote `data` then `pytype`, while `PyAttr.deserialize` read them in the
+    opposite order, so a definition emitted in `data` could be referenced from
+    `pytype` before it was decoded.
+
+    With that pair aligned, no well-formed payload puts a reference first. The
+    rescan is gone and the contract is explicit: a `serialize` /`deserialize`
+    pair must read its fields in the order it writes them.
+    """
+    shared = types.TypeVar(f"OutOfOrder-{transport}")
+    method = _method_with_fields(shared, shared)
+    module = method.dialects.encode(method)
+
+    definition, reference = _field_units(module)
+    assert definition.kind == "attribute"
+    assert reference.kind == "attr_ref"
+    assert reference.data["id"] == definition.data["id"]
+
+    # swap them: the reference now precedes its definition on the wire
+    fields = _field_units(module)
+    fields[:] = [reference, definition]
+
+    with pytest.raises(ValueError, match=r"dangling attr_ref 't[0-9]+'"):
+        method.dialects.decode(_through_transport(module, transport))

--- a/test/serialization/test_version.py
+++ b/test/serialization/test_version.py
@@ -13,13 +13,11 @@ def simple_kernel(x: int):
 
 def _empty_module(version: str = "") -> SerializationModule:
     encoded = basic.encode(simple_kernel)
-    return SerializationModule(
-        symbol_table=encoded.symbol_table, body=encoded.body, version=version
-    )
+    return SerializationModule(body=encoded.body, version=version)
 
 
 def test_serialization_module_default_version_is_empty():
-    mod = SerializationModule(symbol_table={}, body=basic.encode(simple_kernel).body)
+    mod = SerializationModule(body=basic.encode(simple_kernel).body)
     assert mod.version == ""
 
 


### PR DESCRIPTION
### Summary
This is a breaking payload-representation change. Methods are now defined using identity-based IDs, repeated call sites use `method_ref`, and the previous `symbol_table`/mangled-method representation is removed.
Payloads containing the old mangled method records are not supported by this decoder.
Explicit codec versioning and the policy for rejecting unversioned payloads are separated into the stacked follow-up PR #720

### Motivation
Previously, every call site serialized and reconstructed the complete method wrapper, body already de-duplicated with `region_ref`.
On the representative shared-callee benchmark, relative to #713:
- JSON: 61,470 → 42,459 bytes (−31%)
- CBSON: 5,021 → 4,566 bytes (−9%)
- JSON round trip: 4.36 → 2.31 ms (−47%)
- CBSON round trip: 6.22 → 4.24 ms (−32%)
