### PR TITLE
perf: cache interpreter registry and statement trait lookups

### DIFF
--- a/src/kirin/ir/dialect.py
+++ b/src/kirin/ir/dialect.py
@@ -105,6 +105,7 @@ class Dialect:
 
 
         """
+        from kirin.registry import invalidate_interpreter_cache
         from kirin.interp.table import MethodTable
         from kirin.lowering.python.dialect import FromPythonAST
 
@@ -127,6 +128,8 @@ class Dialect:
                         f"Cannot register {node} to Dialect, key {key} exists in {self}"
                     )
                 self.interps[key] = node()
+                # Any group already holding this dialect has a stale registry.
+                invalidate_interpreter_cache()
             elif issubclass(node, FromPythonAST):
                 if key in self.lowering:
                     raise ValueError(

--- a/src/kirin/ir/group.py
+++ b/src/kirin/ir/group.py
@@ -65,12 +65,22 @@ class DialectGroup(Generic[PassParams]):
         default_factory=dict, init=False, repr=False
     )
 
+    _interpreter_cache: dict[tuple[str, ...], tuple[int, dict]] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
+    """Interpreter registries built from this group, keyed by the interpreter keys.
+
+    Each entry is `(registry epoch, table)`; see
+    [`Registry.interpreter`][kirin.registry.Registry.interpreter].
+    """
+
     def __init__(
         self,
         dialects: Iterable[Union["Dialect", ModuleType]],
         run_pass: RunPassGen[PassParams] | None = None,
     ):
         self.symbol_table = {}
+        self._interpreter_cache = {}
         self.data = frozenset(self.map_module(dialect) for dialect in dialects)
         if run_pass is None:
             self.run_pass_gen = None

--- a/src/kirin/ir/nodes/stmt.py
+++ b/src/kirin/ir/nodes/stmt.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping, TypeVar, ClassVar, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar, ClassVar, Iterator, Sequence
 from dataclasses import field, dataclass
 
 from typing_extensions import Self
@@ -22,6 +22,18 @@ if TYPE_CHECKING:
     from kirin.ir.attrs.types import TypeAttribute
     from kirin.ir.nodes.block import Block
     from kirin.ir.nodes.region import Region
+
+
+_TRAIT_MISSING = object()
+"""Sentinel distinguishing "not cached yet" from a cached `None`."""
+
+_trait_cache: dict[tuple[type, type], Any] = {}
+"""Memoized `Statement.get_trait` results, keyed by `(statement class, trait class)`.
+
+Statement classes are module-level and their `traits` are an immutable ClassVar,
+so entries never go stale and the cache is bounded by the number of
+(statement, trait) pairs actually queried.
+"""
 
 
 @dataclass
@@ -746,29 +758,36 @@ class Statement(IRNode["Block"]):
         Returns:
             bool: True if the class has the specified trait, False otherwise.
         """
-        for trait in cls.traits:
-            if isinstance(trait, trait_type):
-                return True
-        return False
+        return cls.get_trait(trait_type) is not None
 
     TraitType = TypeVar("TraitType", bound=Trait["Statement"])
 
     @classmethod
     def get_trait(cls, trait: type[TraitType]) -> TraitType | None:
         """Get the trait of the Statement."""
-        for t in cls.traits:
-            if isinstance(t, trait):
-                return t
-        return None
+        # `traits` is an immutable ClassVar fixed at class creation, so the
+        # answer depends only on `(cls, trait)`. Rewrite passes ask this
+        # millions of times per run -- every purity check walks the trait set
+        # doing ABC isinstance dispatch -- so memoize it per class.
+        key = (cls, trait)
+        found = _trait_cache.get(key, _TRAIT_MISSING)
+        if found is _TRAIT_MISSING:
+            found = None
+            for t in cls.traits:
+                if isinstance(t, trait):
+                    found = t
+                    break
+            _trait_cache[key] = found
+        return found
 
     @classmethod
     def get_present_trait(cls, trait: type[TraitType]) -> TraitType:
         """Just like get_trait, but expects the trait to be there.
         Useful for linter checks, when you know the trait is present."""
-        for t in cls.traits:
-            if isinstance(t, trait):
-                return t
-        raise ValueError(f"Trait {trait} not present in statement {cls}")
+        found = cls.get_trait(trait)
+        if found is None:
+            raise ValueError(f"Trait {trait} not present in statement {cls}")
+        return found
 
     def expect_one_result(self) -> ResultValue:
         """Check if the statement contain only one result, and return it"""

--- a/src/kirin/registry.py
+++ b/src/kirin/registry.py
@@ -31,6 +31,26 @@ class LoweringRegistry:
     callee_table: dict[object, CallLoweringFunction]
 
 
+_registry_epoch = 0
+"""Bumped whenever a dialect gains a new method table.
+
+`Registry.interpreter` caches the tables it builds on the `DialectGroup`, which
+is only sound while no dialect in that group registers new implementations.
+Registration normally happens at import time, before any group is built, but
+`Dialect.register` may be called at any point, so it bumps this counter to
+invalidate every cached table.
+"""
+
+
+def invalidate_interpreter_cache() -> None:
+    """Discard every cached interpreter registry.
+
+    Called by `Dialect.register` when a new method table is added.
+    """
+    global _registry_epoch
+    _registry_epoch += 1
+
+
 @dataclass
 class Registry:
     """Proxy class to build different registries from a dialect group."""
@@ -82,7 +102,33 @@ class Registry:
         Returns:
             a map of statement signatures to their interpretation functions,
             and a map of dialects to their fallback interpreters.
+
+        Note:
+            The returned mapping is cached and shared between callers. Treat it
+            as read-only; mutating it would corrupt other interpreters built
+            from the same dialect group.
         """
+        # Building this table walks every method table of every dialect with
+        # `inspect.getmembers`, which is expensive, and
+        # `Interpreter.__post_init__` asks for it on every interpreter instance.
+        # `Method.__call__` builds a fresh interpreter per call, so calling a
+        # kernel from Python in a loop rebuilds the identical table every time.
+        # The result depends only on the dialect group and the interpreter keys,
+        # so cache it on the group.
+        cache_key = tuple(keys)
+        cached = self.dialects._interpreter_cache.get(cache_key)
+        if cached is not None:
+            epoch, table = cached
+            if epoch == _registry_epoch:
+                return table
+
+        table = self._build_interpreter(cache_key)
+        self.dialects._interpreter_cache[cache_key] = (_registry_epoch, table)
+        return table
+
+    def _build_interpreter(
+        self, keys: tuple[str, ...]
+    ) -> dict["Signature", "BoundedDef"]:
         from kirin.interp.table import BoundedDef
 
         registry: dict[Signature, BoundedDef] = {}

--- a/test/ir/test_interpreter_registry_cache.py
+++ b/test/ir/test_interpreter_registry_cache.py
@@ -1,10 +1,10 @@
 """`Registry.interpreter` caches its table on the dialect group."""
 
 from kirin import ir
-from kirin.interp import Signature, MethodTable, impl
 from kirin.decl import info, statement
-from kirin.dialects import py
+from kirin.interp import Signature, MethodTable, impl
 from kirin.prelude import basic_no_opt
+from kirin.dialects import py
 
 dialect = ir.Dialect("test_registry_cache")
 

--- a/test/ir/test_interpreter_registry_cache.py
+++ b/test/ir/test_interpreter_registry_cache.py
@@ -1,0 +1,62 @@
+"""`Registry.interpreter` caches its table on the dialect group."""
+
+from kirin import ir
+from kirin.interp import Signature, MethodTable, impl
+from kirin.decl import info, statement
+from kirin.dialects import py
+from kirin.prelude import basic_no_opt
+
+dialect = ir.Dialect("test_registry_cache")
+
+
+@statement(dialect=dialect)
+class Noop(ir.Statement):
+    name = "noop"
+    value: int = info.attribute()
+
+
+def test_same_keys_reuse_the_same_table():
+    group = basic_no_opt
+    first = group.registry.interpreter(keys=["main"])
+    second = group.registry.interpreter(keys=["main"])
+    # identity, not just equality: the table is shared, never copied
+    assert first is second
+
+
+def test_different_keys_get_different_tables():
+    group = basic_no_opt
+    main = group.registry.interpreter(keys=["main"])
+    constprop = group.registry.interpreter(keys=["constprop", "main"])
+    assert main is not constprop
+
+
+def test_cache_is_per_group():
+    a = ir.DialectGroup([py.constant, py.binop])
+    b = ir.DialectGroup([py.constant])
+    assert a.registry.interpreter(keys=["main"]) is not b.registry.interpreter(
+        keys=["main"]
+    )
+
+
+def test_cached_table_matches_a_fresh_build():
+    group = basic_no_opt
+    cached = group.registry.interpreter(keys=["main"])
+    fresh = group.registry._build_interpreter(("main",))
+    assert cached == fresh
+
+
+def test_registering_a_new_method_table_invalidates_the_cache():
+    """`Dialect.register` can add interpreters after a group is built."""
+    group = ir.DialectGroup([dialect, py.constant])
+    before = group.registry.interpreter(keys=["main"])
+    assert Signature(Noop) not in before
+
+    @dialect.register
+    class NoopMethods(MethodTable):
+        @impl(Noop)
+        def noop(self, interp, frame, stmt):
+            return ()
+
+    after = group.registry.interpreter(keys=["main"])
+    assert after is not before
+    assert Signature(Noop) in after

--- a/test/ir/test_trait_cache.py
+++ b/test/ir/test_trait_cache.py
@@ -1,0 +1,78 @@
+"""`Statement.get_trait` and friends are memoized; check they stay correct."""
+
+import pytest
+
+from kirin import ir
+from kirin.ir import Pure, Statement
+from kirin.decl import info, statement
+from kirin.dialects import py
+from kirin.ir.nodes.stmt import _trait_cache
+
+dialect = ir.Dialect("test_trait_cache")
+
+
+@statement(dialect=dialect)
+class WithPure(Statement):
+    name = "with_pure"
+    traits = frozenset({Pure()})
+    value: int = info.attribute()
+
+
+@statement(dialect=dialect)
+class WithoutPure(Statement):
+    name = "without_pure"
+    value: int = info.attribute()
+
+
+def test_get_trait_hit_and_miss():
+    assert isinstance(WithPure.get_trait(Pure), Pure)
+    assert WithoutPure.get_trait(Pure) is None
+
+    # repeated queries go through the cache and must agree
+    assert isinstance(WithPure.get_trait(Pure), Pure)
+    assert WithoutPure.get_trait(Pure) is None
+
+
+def test_has_trait_matches_get_trait():
+    assert WithPure.has_trait(Pure) is True
+    assert WithoutPure.has_trait(Pure) is False
+
+
+def test_negative_result_is_cached_not_recomputed():
+    _trait_cache.pop((WithoutPure, Pure), None)
+    assert WithoutPure.get_trait(Pure) is None
+    # a cached `None` must be distinguishable from "not cached yet"
+    assert (WithoutPure, Pure) in _trait_cache
+    assert WithoutPure.get_trait(Pure) is None
+
+
+def test_sibling_classes_do_not_share_entries():
+    """A cache keyed only on the trait would leak between statement classes."""
+    assert WithPure.has_trait(Pure) is True
+    assert WithoutPure.has_trait(Pure) is False
+    assert WithPure.has_trait(Pure) is True
+
+
+def test_get_present_trait():
+    assert isinstance(WithPure.get_present_trait(Pure), Pure)
+    with pytest.raises(ValueError):
+        WithoutPure.get_present_trait(Pure)
+
+
+def test_matches_uncached_scan_for_real_dialect_statements():
+    """Cached answers must equal a direct scan over `cls.traits`."""
+
+    def uncached(cls, trait):
+        for t in cls.traits:
+            if isinstance(t, trait):
+                return t
+        return None
+
+    for cls in (py.Constant, py.Add, py.GetItem, WithPure, WithoutPure):
+        for trait in (Pure, ir.ConstantLike, ir.IsTerminator):
+            expected = uncached(cls, trait)
+            got = cls.get_trait(trait)
+            assert (got is None) == (expected is None)
+            if expected is not None:
+                assert isinstance(got, trait)
+            assert cls.has_trait(trait) is (expected is not None)


### PR DESCRIPTION
## Summary

Two independent caches for values that are invariant but recomputed constantly. Both were found by profiling a compile-heavy workload where ~19s of a 38s run was `inspect.getmembers`.

### 1. Cache the interpreter registry on the dialect group

`Registry.interpreter` builds its `Signature -> BoundedDef` table by walking every method table of every dialect with `inspect.getmembers`. `Interpreter.__post_init__` requests that table for every interpreter instance, and `Method.__call__` constructs a fresh `Interpreter` on every call:

```python
def __call__(self, *args, **kwargs):
    interp = Interpreter(self.dialects)   # rebuilds the whole registry
    _, ret = interp.run(self, *args, **kwargs)
    return ret
```

So **calling a kernel from Python costs O(size of the dialect group) per call**, independent of what the kernel does. With the `basic` prelude (26 dialects) that dominates: in a profile of 20k calls, `inspect.getmembers` alone accounted for 429,903 calls and ~4.8s of self time.

The table depends only on `(dialect group, interpreter keys)`, so it is now cached on the group. `Dialect.register` can add method tables after a group exists, so it bumps a module-level epoch that invalidates every cached table.

One subtlety worth flagging for review: the cached table is **shared, not copied**. `Interpreter` only reads it (`in`, `.get`, `[]`). I first returned a defensive copy, and copying per call is itself expensive enough to erase the win entirely, so `interpreter()` now documents the mapping as read-only.

### 2. Memoize `Statement` trait lookups

`has_trait` / `get_trait` / `get_present_trait` each scan `cls.traits` with an ABC `isinstance` per entry. Rewrite passes hammer these — every purity check in `DeadCodeElimination` goes through `is_pure` — and a single `Fold` over a 56-method call graph performs ~305k lookups.

`traits` is an immutable `ClassVar[frozenset]` fixed at class creation, so the result depends only on `(cls, trait)`. `has_trait` and `get_present_trait` now route through `get_trait` so all three share one cache and one definition of matching.

## Benchmark (MWE)

```python
import gc, time, statistics
from kirin.ir import Method
from kirin.passes import Fold
from kirin.prelude import basic, basic_no_opt

@basic
def kernel(x: int) -> int:
    y = x + 1
    z = y * 2
    return z - 1

def _leaf() -> Method:
    @basic_no_opt
    def leaf(x: int) -> int:
        y = x + 1
        z = y * 2
        return z - 1
    return leaf

def _node(a: Method, b: Method, c: Method) -> Method:
    @basic_no_opt
    def node(x: int) -> int:
        p = a(x)
        q = b(p)
        r = c(q)
        return p + q + r
    return node

def build(width=8, layers=7) -> Method:
    """`layers` layers of `width` kernels; each calls three below it."""
    level = [_leaf() for _ in range(width)]
    for _ in range(layers):
        level = [
            _node(level[i % len(level)],
                  level[(i + 1) % len(level)],
                  level[(i + 2) % len(level)])
            for i in range(width)
        ]
    return _node(level[0], level[1], level[2])

def bench(label, make, run, repeats=7):
    samples = []
    for _ in range(repeats):
        payload = make()
        gc.collect()
        t0 = time.perf_counter()
        run(payload)
        samples.append(time.perf_counter() - t0)
    print(f"  {label:24s} best={min(samples):7.3f}s median={statistics.median(samples):7.3f}s")

bench("20000 kernel calls", lambda: None,
      lambda _: [kernel(3) for _ in range(20000)])
bench("Fold (56 methods)", lambda: build(),
      lambda mt: Fold(mt.dialects)(mt))
```

| | main | this PR |
|---|---|---|
| 20,000 `Method.__call__` | 5.155s | **0.456s** (11.3x) |
| `Fold` over 56-method call graph | 1.237s | 1.194s (~3%) |

The `Fold` row is the trait cache measured on its own; it is a modest win and is a separate commit so it can be dropped independently. The registry cache is the headline.

As an incidental datapoint, kirin's own test suite goes from **7.40s to 2.69s**.

## Correctness

- `traits` is an immutable `ClassVar[frozenset]` and is never reassigned anywhere in `src/`; the cache is keyed per `(class, trait)` so sibling classes cannot share entries, and a cached `None` is distinguished from "not cached" by a sentinel.
- `DialectGroup.data` is a `frozenset` assigned once in `__init__`, so a per-group cache cannot go stale from group mutation. The one real staleness path, `Dialect.register`, is handled by the epoch counter and covered by a test.
- 11 new tests; full suite passes (715 passed, 13 xfailed, 1 xpassed), `pyright` clean, `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
