### PR TITLE
Lower IList functional combinators to scf loops

### DIFF
--- a/src/kirin/dialects/ilist/__init__.py
+++ b/src/kirin/dialects/ilist/__init__.py
@@ -23,7 +23,7 @@ from .stmts import (
     ForEach as ForEach,
     IListType as IListType,
 )
-from .passes import IListDesugar as IListDesugar
+from .passes import IListToLoop as IListToLoop, IListDesugar as IListDesugar
 from .runtime import IList as IList
 from ._dialect import dialect as dialect
 from ._wrapper import (  # careful this is not the builtin range

--- a/src/kirin/dialects/ilist/interp.py
+++ b/src/kirin/dialects/ilist/interp.py
@@ -1,3 +1,6 @@
+import typing
+from collections.abc import Iterable
+
 from kirin import ir, types
 from kirin.interp import Frame, Interpreter, MethodTable, impl
 from kirin.dialects.py.len import Len
@@ -67,25 +70,36 @@ class IListInterpreter(MethodTable):
             return ((carry, IList(ys, types.Any)),)
 
     @impl(Foldr)
-    def foldr(self, interp: Interpreter, frame: Frame, stmt: Foldr):
+    def foldr(
+        self, interp: Interpreter, frame: Frame, stmt: Foldr
+    ) -> tuple[typing.Any]:
         return self.fold(
             interp, frame, stmt, reversed(frame.get_casted(stmt.collection, IList).data)
         )
 
     @impl(Foldl)
-    def foldl(self, interp: Interpreter, frame: Frame, stmt: Foldl):
+    def foldl(
+        self, interp: Interpreter, frame: Frame, stmt: Foldl
+    ) -> tuple[typing.Any]:
         return self.fold(
             interp, frame, stmt, frame.get_casted(stmt.collection, IList).data
         )
 
-    def fold(self, interp: Interpreter, frame: Frame, stmt: Foldr | Foldl, coll):
-        fn: ir.Method = frame.get(stmt.fn)
+    def fold(
+        self,
+        interp: Interpreter,
+        frame: Frame,
+        stmt: Foldr | Foldl,
+        coll: Iterable[typing.Any],
+    ) -> tuple[typing.Any]:
+        fn: ir.Method[..., typing.Any] = frame.get(stmt.fn)
         init = frame.get(stmt.init)
 
         acc = init
         for elem in coll:
             # NOTE: assume fn has been type checked
-            _, acc = interp.call(fn.code, fn, acc, elem)
+            inputs = (elem, acc) if isinstance(stmt, Foldr) else (acc, elem)
+            _, acc = interp.call(fn.code, fn, *inputs)
         return (acc,)
 
     @impl(ForEach)

--- a/src/kirin/dialects/ilist/passes.py
+++ b/src/kirin/dialects/ilist/passes.py
@@ -1,8 +1,21 @@
+from typing import Any
+from dataclasses import field, dataclass
+
 from kirin import ir, types
 from kirin.rewrite import Walk, Chain, Fixpoint
 from kirin.passes.abc import Pass
-from kirin.rewrite.abc import RewriteResult
-from kirin.dialects.ilist.rewrite import List2IList, ConstList2IList
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.passes.typeinfer import TypeInfer
+from kirin.dialects.ilist.rewrite import (
+    List2IList,
+    AllToForLoop,
+    AnyToForLoop,
+    MapToForLoop,
+    FoldToForLoop,
+    ScanToForLoop,
+    ConstList2IList,
+    ForEachToForLoop,
+)
 
 
 class IListDesugar(Pass):
@@ -11,10 +24,51 @@ class IListDesugar(Pass):
     constant `list` type into `IList` type.
     """
 
-    def unsafe_run(self, mt: ir.Method) -> RewriteResult:
+    def unsafe_run(self, mt: ir.Method[..., Any]) -> RewriteResult:
         for arg in mt.args:
             _check_list(arg.type, arg.type)
         return Fixpoint(Walk(Chain(ConstList2IList(), List2IList()))).rewrite(mt.code)
+
+
+@dataclass
+class IListToLoop(Pass):
+    """Lower IList combinators to indexed SCF loops within one method.
+
+    Handles Map, Foldl, Foldr, Scan, ForEach, Any and All. The result retains
+    callback calls, IList construction and concatenation, integer indexing,
+    ranges, tuples, and arithmetic. Separate callee bodies are unchanged.
+
+    Requires current inferred types. For methods not marked inferred, runs
+    type inference first. Rules leave unsupported type representations unchanged;
+    callers requiring complete normalization must check for residual combinators.
+
+    The dialect group must include scf, func, ilist, py.constant, py.len,
+    py.indexing, py.binop, py.boolop, and py.tuple.
+    """
+
+    typeinfer: TypeInfer = field(init=False)
+    rule: RewriteRule = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.typeinfer = TypeInfer(self.dialects, no_raise=self.no_raise)
+        self.rule = Fixpoint(
+            Walk(
+                Chain(
+                    MapToForLoop(),
+                    FoldToForLoop(),
+                    ScanToForLoop(),
+                    ForEachToForLoop(),
+                    AnyToForLoop(),
+                    AllToForLoop(),
+                )
+            )
+        )
+
+    def unsafe_run(self, mt: ir.Method[..., Any]) -> RewriteResult:
+        result = RewriteResult()
+        if not mt.inferred:
+            result = self.typeinfer.unsafe_run(mt)
+        return self.rule.rewrite(mt.code).join(result)
 
 
 def _check_list(total: types.TypeAttribute, type_: types.TypeAttribute):

--- a/src/kirin/dialects/ilist/rewrite/__init__.py
+++ b/src/kirin/dialects/ilist/rewrite/__init__.py
@@ -1,6 +1,14 @@
 from .list import List2IList as List2IList
 from .const import ConstList2IList as ConstList2IList
 from .unroll import Unroll as Unroll
+from .to_loop import (
+    AllToForLoop as AllToForLoop,
+    AnyToForLoop as AnyToForLoop,
+    MapToForLoop as MapToForLoop,
+    FoldToForLoop as FoldToForLoop,
+    ScanToForLoop as ScanToForLoop,
+    ForEachToForLoop as ForEachToForLoop,
+)
 from .hint_len import HintLen as HintLen
 from .flatten_add import FlattenAdd as FlattenAdd
 from .to_range_loop import ToRangeFor as ToRangeFor

--- a/src/kirin/dialects/ilist/rewrite/to_loop.py
+++ b/src/kirin/dialects/ilist/rewrite/to_loop.py
@@ -1,0 +1,388 @@
+from kirin import ir, types
+from kirin.dialects import py, scf, func, ilist
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.ir.nodes.stmt import Statement
+
+
+class MapToForLoop(RewriteRule):
+    """Rewrite `ilist.map` into an indexed loop that accumulates callback results.
+
+    For example, rewrites:
+    ```python
+    ys = ilist.map(fn, xs)
+    ```
+
+    to:
+    ```python
+    ys = []
+    for i in range(len(xs)):
+        ys = ys + [fn(xs[i])]
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, ilist.Map):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        result_type = node.result.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType)
+            and isinstance(result_type, types.Generic)
+            and result_type.is_subseteq(ilist.IListType)
+        ):
+            return RewriteResult()
+
+        input_element_type = collection_type.vars[0]
+        output_element_type = result_type.vars[0]
+        accumulator_type = ilist.IListType[output_element_type, types.Any]
+
+        length = py.Len(node.collection)
+        zero = py.Constant(0)
+        one = py.Constant(1)
+        indices = ilist.stmts.Range(zero.result, length.result, one.result)
+        empty = ilist.New((), elem_type=output_element_type)
+
+        body = ir.Block(argtypes=(types.Int, accumulator_type))
+        index, accumulated = body.args
+
+        element = py.GetItem(node.collection, index)
+        element.result.type = input_element_type
+
+        call = func.Call(
+            callee=node.fn,
+            inputs=(element.result,),
+            kwargs=(),
+        )
+        call.result.type = output_element_type
+
+        singleton = ilist.New((call.result,), elem_type=output_element_type)
+        appended = py.Add(accumulated, singleton.result)
+        appended.result.type = accumulator_type
+
+        for stmt in (element, call, singleton, appended, scf.Yield(appended.result)):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body), empty.result)
+        loop.results[0].type = result_type
+
+        for stmt in (length, zero, one, indices, empty, loop):
+            stmt.insert_before(node)
+
+        node.result.replace_by(loop.results[0])
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class FoldToForLoop(RewriteRule):
+    """Rewrite folds into indexed loops.
+
+    Foldl traverses forward with accumulator-first callbacks. Foldr traverses
+    backward with element-first callbacks.
+
+    For example, rewrites:
+    ```python
+    result = ilist.foldl(fn, xs, initial)
+    ```
+
+    to:
+    ```python
+    result = initial
+    for i in range(len(xs)):
+        result = fn(result, xs[i])
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, (ilist.Foldl, ilist.Foldr)):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType)
+        ):
+            return RewriteResult()
+
+        element_type = collection_type.vars[0]
+        accumulator_type = node.result.type
+
+        length = py.Len(node.collection)
+        setup: list[Statement] = [length]
+        if isinstance(node, ilist.Foldr):
+            one = py.Constant(1)
+            last = py.Sub(length.result, one.result)
+            last.result.type = types.Int
+            negative_one = py.Constant(-1)
+            setup.extend((one, last, negative_one))
+            indices = ilist.stmts.Range(
+                last.result, negative_one.result, negative_one.result
+            )
+        else:
+            zero = py.Constant(0)
+            one = py.Constant(1)
+            setup.extend((zero, one))
+            indices = ilist.stmts.Range(zero.result, length.result, one.result)
+
+        body = ir.Block(argtypes=(types.Int, accumulator_type))
+        index, accumulator = body.args
+
+        element = py.GetItem(node.collection, index)
+        element.result.type = element_type
+
+        inputs = (
+            (element.result, accumulator)
+            if isinstance(node, ilist.Foldr)
+            else (accumulator, element.result)
+        )
+        call = func.Call(callee=node.fn, inputs=inputs, kwargs=())
+        call.result.type = accumulator_type
+
+        for stmt in (element, call, scf.Yield(call.result)):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body), node.init)
+
+        for stmt in (*setup, indices, loop):
+            stmt.insert_before(node)
+
+        node.result.replace_by(loop.results[0])
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class ScanToForLoop(RewriteRule):
+    """Rewrite Scan into an indexed loop carrying state and an output list.
+
+    Requires inferred input and result types.
+
+    For example, rewrites:
+    ```python
+    result = ilist.scan(fn, xs, initial)
+    ```
+
+    to:
+    ```python
+    state = initial
+    outputs = []
+    for i in range(len(xs)):
+        pair = fn(state, xs[i])
+        state = pair[0]
+        outputs = outputs + [pair[1]]
+    result = (state, outputs)
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, ilist.Scan):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        result_type = node.result.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType)
+            and isinstance(result_type, types.Generic)
+            and result_type.is_subseteq(types.Tuple)
+            and len(result_type.vars) == 2
+        ):
+            return RewriteResult()
+
+        state_type, output_type = result_type.vars
+        if not (
+            isinstance(output_type, types.Generic)
+            and output_type.is_subseteq(ilist.IListType)
+        ):
+            return RewriteResult()
+
+        output_element_type = output_type.vars[0]
+        accumulated_type = ilist.IListType[output_element_type, types.Any]
+        length = py.Len(node.collection)
+        zero = py.Constant(0)
+        one = py.Constant(1)
+        indices = ilist.stmts.Range(zero.result, length.result, one.result)
+        empty = ilist.New((), elem_type=output_element_type)
+
+        body = ir.Block(argtypes=(types.Int, state_type, accumulated_type))
+        index, state, accumulated = body.args
+        element = py.GetItem(node.collection, index)
+        element.result.type = collection_type.vars[0]
+        call = func.Call(callee=node.fn, inputs=(state, element.result), kwargs=())
+        call.result.type = types.Tuple[state_type, output_element_type]
+        next_state = py.GetItem(call.result, zero.result)
+        next_state.result.type = state_type
+        value = py.GetItem(call.result, one.result)
+        value.result.type = output_element_type
+        singleton = ilist.New((value.result,), elem_type=output_element_type)
+        appended = py.Add(accumulated, singleton.result)
+        appended.result.type = accumulated_type
+
+        for stmt in (
+            element,
+            call,
+            next_state,
+            value,
+            singleton,
+            appended,
+            scf.Yield(next_state.result, appended.result),
+        ):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body), node.init, empty.result)
+        loop.results[1].type = output_type
+        result = py.tuple.New((loop.results[0], loop.results[1]))
+        result.result.type = result_type
+
+        for stmt in (length, zero, one, indices, empty, loop, result):
+            stmt.insert_before(node)
+
+        node.result.replace_by(result.result)
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class ForEachToForLoop(RewriteRule):
+    """Rewrite ForEach into an indexed loop preserving callback order and effects.
+
+    For example, rewrites:
+    ```python
+    ilist.for_each(fn, xs)
+    ```
+
+    to:
+    ```python
+    for i in range(len(xs)):
+        fn(xs[i])
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, ilist.ForEach):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType)
+        ):
+            return RewriteResult()
+
+        length = py.Len(node.collection)
+        zero = py.Constant(0)
+        one = py.Constant(1)
+        indices = ilist.stmts.Range(zero.result, length.result, one.result)
+        body = ir.Block(argtypes=(types.Int,))
+        element = py.GetItem(node.collection, body.args[0])
+        element.result.type = collection_type.vars[0]
+        call = func.Call(callee=node.fn, inputs=(element.result,), kwargs=())
+        callback_type = node.fn.type
+        if isinstance(callback_type, types.FunctionType):
+            if callback_type.return_type is not None:
+                call.result.type = callback_type.return_type
+        for stmt in (element, call, scf.Yield()):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body))
+        for stmt in (length, zero, one, indices, loop):
+            stmt.insert_before(node)
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class AnyToForLoop(RewriteRule):
+    """Rewrite Any into an OR reduction over an immutable boolean list.
+
+    For example, rewrites:
+    ```python
+    result = ilist.any(xs)
+    ```
+
+    to:
+    ```python
+    result = False
+    for i in range(len(xs)):
+        value = xs[i]
+        result = result or value
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, ilist.stmts.Any):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType[types.Bool])
+        ):
+            return RewriteResult()
+
+        length = py.Len(node.collection)
+        zero = py.Constant(0)
+        one = py.Constant(1)
+        indices = ilist.stmts.Range(zero.result, length.result, one.result)
+        initial = py.Constant(False)
+        body = ir.Block(argtypes=(types.Int, types.Bool))
+        index, accumulated = body.args
+        element = py.GetItem(node.collection, index)
+        element.result.type = types.Bool
+        combined = py.Or(accumulated, element.result)
+        for stmt in (element, combined, scf.Yield(combined.result)):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body), initial.result)
+        for stmt in (length, zero, one, indices, initial, loop):
+            stmt.insert_before(node)
+        node.result.replace_by(loop.results[0])
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class AllToForLoop(RewriteRule):
+    """Rewrite All into an AND reduction over an immutable boolean list.
+
+    For example, rewrites:
+    ```python
+    result = ilist.all(xs)
+    ```
+
+    to:
+    ```python
+    result = True
+    for i in range(len(xs)):
+        value = xs[i]
+        result = result and value
+    ```
+    """
+
+    def rewrite_Statement(self, node: Statement) -> RewriteResult:
+        if not isinstance(node, ilist.stmts.All):
+            return RewriteResult()
+
+        collection_type = node.collection.type
+        if not (
+            isinstance(collection_type, types.Generic)
+            and collection_type.is_subseteq(ilist.IListType[types.Bool])
+        ):
+            return RewriteResult()
+
+        length = py.Len(node.collection)
+        zero = py.Constant(0)
+        one = py.Constant(1)
+        indices = ilist.stmts.Range(zero.result, length.result, one.result)
+        initial = py.Constant(True)
+        body = ir.Block(argtypes=(types.Int, types.Bool))
+        index, accumulated = body.args
+        element = py.GetItem(node.collection, index)
+        element.result.type = types.Bool
+        combined = py.And(accumulated, element.result)
+        for stmt in (element, combined, scf.Yield(combined.result)):
+            body.stmts.append(stmt)
+
+        loop = scf.For(indices.result, ir.Region(body), initial.result)
+        for stmt in (length, zero, one, indices, initial, loop):
+            stmt.insert_before(node)
+        node.result.replace_by(loop.results[0])
+        node.delete()
+        return RewriteResult(has_done_something=True)

--- a/src/kirin/dialects/ilist/rewrite/unroll.py
+++ b/src/kirin/dialects/ilist/rewrite/unroll.py
@@ -109,7 +109,8 @@ class Unroll(RewriteRule):
             elt = GetItem(node.collection, index.result)
             elt.insert_before(node)
 
-            acc_stmt = Call(node.fn, (acc, elt.result), ())
+            inputs = (elt.result, acc) if reversed else (acc, elt.result)
+            acc_stmt = Call(node.fn, inputs, ())
             acc_stmt.insert_before(node)
             acc = acc_stmt.result
 

--- a/src/kirin/dialects/ilist/stmts.py
+++ b/src/kirin/dialects/ilist/stmts.py
@@ -73,6 +73,8 @@ class Map(ir.Statement):
 
 @statement(dialect=dialect)
 class Foldr(ir.Statement):
+    """Fold right to left, passing each element before the accumulator."""
+
     traits = frozenset({ir.MaybePure(), lowering.FromPythonCall()})
     purity: bool = info.attribute(default=False)
     fn: ir.SSAValue = info.argument(types.MethodType[[ElemT, OutElemT], OutElemT])

--- a/test/dialects/ilist/test_foldr.py
+++ b/test/dialects/ilist/test_foldr.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+import pytest
+
+from kirin import types
+from kirin.passes import TypeInfer
+from kirin.prelude import structural_no_opt
+from kirin.rewrite import Walk
+from kirin.dialects import ilist
+
+
+@pytest.mark.parametrize("unroll", [False, True])
+def test_foldr_element_precedes_accumulator(unroll: bool) -> None:
+    @structural_no_opt
+    def step(x: int, acc: tuple[int, int]) -> tuple[int, int]:
+        return (10 * acc[0] + x, acc[1] + 1)
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Literal[3]]) -> tuple[int, int]:
+        return ilist.foldr(step, xs, (0, 0))
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    assert folded(xs) == (321, 3)
+    TypeInfer(folded.dialects, no_raise=False)(folded)
+    assert folded.return_type == types.Tuple[types.Int, types.Int]
+    folded.verify_type()
+    if unroll:
+        assert Walk(ilist.rewrite.Unroll()).rewrite(folded.code).has_done_something
+        folded.verify()
+    assert folded(xs) == (321, 3)
+
+
+@pytest.mark.parametrize("unroll", [False, True])
+@pytest.mark.parametrize("initial, expected", [(0, 2), (4, -2)])
+def test_foldr_right_associative_subtraction(
+    unroll: bool, initial: int, expected: int
+) -> None:
+    @structural_no_opt
+    def subtract(x: int, acc: int) -> int:
+        return x - acc
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Literal[3]], initial: int) -> int:
+        return ilist.foldr(subtract, xs, initial)
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    assert folded(xs, initial) == expected
+    TypeInfer(folded.dialects, no_raise=False)(folded)
+    folded.verify_type()
+    if unroll:
+        assert Walk(ilist.rewrite.Unroll()).rewrite(folded.code).has_done_something
+        folded.verify()
+    assert folded(xs, initial) == expected

--- a/test/dialects/ilist/test_to_loop.py
+++ b/test/dialects/ilist/test_to_loop.py
@@ -1,0 +1,525 @@
+from typing import Any, Literal
+from collections.abc import Callable
+
+import pytest
+
+from kirin import ir, types, interp, lowering
+from kirin.decl import info, statement
+from kirin.passes import TypeInfer
+from kirin.prelude import structural_no_opt
+from kirin.rewrite import Walk, Chain
+from kirin.dialects import py, scf, func, ilist
+from kirin.rewrite.abc import RewriteRule
+from kirin.dialects.ilist.rewrite.to_loop import (
+    AllToForLoop,
+    AnyToForLoop,
+    MapToForLoop,
+    FoldToForLoop,
+    ScanToForLoop,
+    ForEachToForLoop,
+)
+
+Recording = tuple[ir.DialectGroup, Callable[[int], None], list[int]]
+
+
+@pytest.fixture
+def recording() -> Recording:
+    dialect = ir.Dialect("test.record")
+    recorded: list[int] = []
+
+    @statement(dialect=dialect)
+    class Record(ir.Statement):
+        traits = frozenset({lowering.FromPythonCall()})
+        value: ir.SSAValue = info.argument(types.Int)
+
+    @dialect.register
+    class Concrete(interp.MethodTable):
+        @interp.impl(Record)
+        def record_value(
+            self, interpreter: interp.Interpreter, frame: interp.Frame, stmt: Record
+        ) -> tuple[()]:
+            recorded.append(frame.get_casted(stmt.value, int))
+            return ()
+
+    @lowering.wraps(Record)
+    def record(value: int) -> None: ...
+
+    return structural_no_opt.add(dialect), record, recorded
+
+
+def lower(
+    method: ir.Method[..., Any],
+    rule: RewriteRule | None = None,
+    statement_types: tuple[type[ir.Statement], ...] = (ilist.Map,),
+) -> tuple[types.TypeAttribute, ...]:
+    TypeInfer(method.dialects, no_raise=False)(method)
+    original_types = tuple(
+        result.type
+        for stmt in method.code.walk()
+        if isinstance(stmt, statement_types)
+        for result in stmt.results
+    )
+    walk = Walk(MapToForLoop() if rule is None else rule)
+    result = walk.rewrite(method.code)
+    assert result.has_done_something
+    assert not result.exceeded_max_iter
+    method.verify()
+    assert not any(isinstance(stmt, statement_types) for stmt in method.code.walk())
+    repeated = walk.rewrite(method.code)
+    assert not repeated.has_done_something
+    assert not repeated.exceeded_max_iter
+    return original_types
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [([], []), ([3], [7]), ([1, 2, 3], [3, 5, 7]), ([-2, 0, 4], [-3, 1, 9])],
+)
+def test_map_to_loop(values: list[int], expected: list[int]) -> None:
+    @structural_no_opt
+    def transform(x: int) -> int:
+        return 2 * x + 1
+
+    @structural_no_opt
+    def mapped(xs: ilist.IList[int, Any]) -> ilist.IList[int, Any]:
+        return ilist.map(transform, xs)
+
+    xs = ilist.IList(values.copy(), elem=types.Int)
+    assert list(mapped(xs)) == expected
+    lower(mapped)
+    assert list(mapped(xs)) == expected
+    assert list(xs) == values
+    assert sum(isinstance(stmt, scf.For) for stmt in mapped.code.walk()) == 1
+
+
+def test_map_preserves_element_and_length_types() -> None:
+    @structural_no_opt
+    def positive(x: int) -> bool:
+        return x > 0
+
+    @structural_no_opt
+    def mapped(xs: ilist.IList[int, Literal[3]]) -> ilist.IList[bool, Literal[3]]:
+        return ilist.map(positive, xs)
+
+    xs = ilist.IList([-1, 0, 1], elem=types.Int)
+    assert list(mapped(xs)) == [False, False, True]
+    lower(mapped)
+    assert list(mapped(xs)) == [False, False, True]
+    loop = next(stmt for stmt in mapped.code.walk() if isinstance(stmt, scf.For))
+    assert loop.results[0].type == ilist.IListType[types.Bool, types.Literal(3)]
+    assert loop.body.blocks[0].args[1].type == ilist.IListType[types.Bool, types.Any]
+    call = next(stmt for stmt in loop.body.walk() if isinstance(stmt, func.Call))
+    assert call.result.type == types.Bool
+    empty = loop.initializers[0]
+    assert empty.type == ilist.IListType[types.Bool, types.Literal(0)]
+
+
+def test_map_captured_value() -> None:
+    @structural_no_opt
+    def mapped(xs: ilist.IList[int, Any], offset: int) -> ilist.IList[int, Any]:
+        def shift(x: int) -> int:
+            return x + offset
+
+        return ilist.map(shift, xs)
+
+    xs = ilist.IList([1, 4], elem=types.Int)
+    assert list(mapped(xs, 7)) == [8, 11]
+    lower(mapped)
+    assert list(mapped(xs, 7)) == [8, 11]
+
+
+@pytest.mark.parametrize("values", [[], [3, 1, 3]])
+def test_map_callback_effects(values: list[int], recording: Recording) -> None:
+    dialects, record, recorded = recording
+
+    @dialects
+    def emit(x: int) -> int:
+        record(x)
+        return x + 1
+
+    @dialects
+    def mapped(xs: ilist.IList[int, Any]) -> ilist.IList[int, Any]:
+        return ilist.map(emit, xs)
+
+    xs = ilist.IList(values, elem=types.Int)
+    assert list(mapped(xs)) == [x + 1 for x in values]
+    assert recorded == values
+    recorded.clear()
+    lower(mapped)
+    assert list(mapped(xs)) == [x + 1 for x in values]
+    assert recorded == values
+    recorded.clear()
+
+
+@pytest.mark.parametrize(
+    ("values", "initial", "expected"),
+    [([], 7, 7), ([3], 2, 23), ([1, 2, 3], 0, 123), ([1, 2, 3], 4, 4123)],
+)
+def test_foldl_to_loop(values: list[int], initial: int, expected: int) -> None:
+    @structural_no_opt
+    def step(acc: int, x: int) -> int:
+        return 10 * acc + x
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Any], initial: int) -> int:
+        return ilist.foldl(step, xs, initial)
+
+    xs = ilist.IList(values.copy(), elem=types.Int)
+    assert folded(xs, initial) == expected
+    lower(folded, FoldToForLoop(), (ilist.Foldl, ilist.Foldr))
+    assert folded(xs, initial) == expected
+    assert list(xs) == values
+    loops = [stmt for stmt in folded.code.walk() if isinstance(stmt, scf.For)]
+    assert len(loops) == 1
+    assert loops[0].results[0].type == types.Int
+    assert loops[0].body.blocks[0].args[1].type == types.Int
+
+
+def test_foldl_distinct_accumulator_type() -> None:
+    @structural_no_opt
+    def step(acc: tuple[int, int], x: int) -> tuple[int, int]:
+        return (acc[0] + x, acc[1] + 1)
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Any]) -> tuple[int, int]:
+        return ilist.foldl(step, xs, (10, 0))
+
+    xs = ilist.IList([2, 3, 4], elem=types.Int)
+    assert folded(xs) == (19, 3)
+    lower(folded, FoldToForLoop(), (ilist.Foldl, ilist.Foldr))
+    assert folded(xs) == (19, 3)
+    loop = next(stmt for stmt in folded.code.walk() if isinstance(stmt, scf.For))
+    assert loop.results[0].type == types.Tuple[types.Int, types.Int]
+    call = next(stmt for stmt in loop.body.walk() if isinstance(stmt, func.Call))
+    assert call.inputs[0].type == types.Tuple[types.Int, types.Int]
+    assert call.inputs[1].type == types.Int
+
+
+@pytest.mark.parametrize("values", [[], [3, 1, 3]])
+def test_foldl_callback_effects(values: list[int], recording: Recording) -> None:
+    dialects, record, recorded = recording
+
+    @dialects
+    def step(acc: int, x: int) -> int:
+        record(x)
+        return acc + x
+
+    @dialects
+    def folded(xs: ilist.IList[int, Any]) -> int:
+        return ilist.foldl(step, xs, 7)
+
+    xs = ilist.IList(values, elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(folded, FoldToForLoop(), (ilist.Foldl, ilist.Foldr))
+        assert folded(xs) == 7 + sum(values)
+        assert recorded == values
+        recorded.clear()
+
+
+@pytest.mark.parametrize(
+    ("values", "initial", "expected"),
+    [([], 7, 7), ([3], 2, 1), ([1, 2, 3], 0, 2), ([1, 2, 3], 4, -2)],
+)
+def test_foldr_to_loop(values: list[int], initial: int, expected: int) -> None:
+    @structural_no_opt
+    def step(x: int, acc: int) -> int:
+        return x - acc
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Any], initial: int) -> int:
+        return ilist.foldr(step, xs, initial)
+
+    xs = ilist.IList(values.copy(), elem=types.Int)
+    assert folded(xs, initial) == expected
+    lower(folded, FoldToForLoop(), (ilist.Foldl, ilist.Foldr))
+    assert folded(xs, initial) == expected
+    assert list(xs) == values
+    loop = next(stmt for stmt in folded.code.walk() if isinstance(stmt, scf.For))
+    assert loop.results[0].type == types.Int
+
+
+def test_foldr_callback_order(recording: Recording) -> None:
+    dialects, record, recorded = recording
+
+    @dialects
+    def step(x: int, acc: int) -> int:
+        record(x)
+        return acc + x
+
+    @dialects
+    def folded(xs: ilist.IList[int, Any]) -> int:
+        return ilist.foldr(step, xs, 0)
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(folded, FoldToForLoop(), (ilist.Foldl, ilist.Foldr))
+        assert folded(xs) == 6
+        assert recorded == [3, 2, 1]
+        recorded.clear()
+
+
+@pytest.mark.parametrize(
+    ("values", "initial", "expected_state", "expected_outputs"),
+    [([], 7, 7, []), ([3], 2, 23, [23]), ([1, 2, 3], 0, 123, [1, 12, 123])],
+)
+def test_scan_to_loop(
+    values: list[int], initial: int, expected_state: int, expected_outputs: list[int]
+) -> None:
+    @structural_no_opt
+    def step(acc: int, x: int) -> tuple[int, int]:
+        next_acc = 10 * acc + x
+        return next_acc, next_acc
+
+    @structural_no_opt
+    def scanned(
+        xs: ilist.IList[int, Any], initial: int
+    ) -> tuple[int, ilist.IList[int, Any]]:
+        return ilist.scan(step, xs, initial)
+
+    xs = ilist.IList(values.copy(), elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(scanned, ScanToForLoop(), (ilist.Scan,))
+        state, outputs = scanned(xs, initial)
+        assert state == expected_state
+        assert list(outputs) == expected_outputs
+        assert list(xs) == values
+
+
+def test_scan_distinct_output_type_and_length() -> None:
+    @structural_no_opt
+    def step(acc: int, x: int) -> tuple[int, bool]:
+        next_acc = acc + x
+        return next_acc, next_acc > 3
+
+    @structural_no_opt
+    def scanned(
+        xs: ilist.IList[int, Literal[3]],
+    ) -> tuple[int, ilist.IList[bool, Literal[3]]]:
+        return ilist.scan(step, xs, 0)
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(scanned, ScanToForLoop(), (ilist.Scan,))
+        state, outputs = scanned(xs)
+        assert state == 6
+        assert list(outputs) == [False, False, True]
+    loop = next(stmt for stmt in scanned.code.walk() if isinstance(stmt, scf.For))
+    assert loop.results[0].type == types.Int
+    assert loop.results[1].type == ilist.IListType[types.Bool, types.Literal(3)]
+    assert loop.body.blocks[0].args[2].type == ilist.IListType[types.Bool, types.Any]
+
+
+@pytest.mark.parametrize("values", [[], [3, 1, 3]])
+def test_scan_callback_effects(values: list[int], recording: Recording) -> None:
+    dialects, record, recorded = recording
+
+    @dialects
+    def step(acc: int, x: int) -> tuple[int, int]:
+        record(x)
+        return acc + x, x
+
+    @dialects
+    def scanned(xs: ilist.IList[int, Any]) -> tuple[int, ilist.IList[int, Any]]:
+        return ilist.scan(step, xs, 7)
+
+    xs = ilist.IList(values, elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(scanned, ScanToForLoop(), (ilist.Scan,))
+        state, outputs = scanned(xs)
+        assert state == 7 + sum(values)
+        assert list(outputs) == values
+        assert recorded == values
+        recorded.clear()
+
+
+@pytest.mark.parametrize("values", [[], [2], [3, 1, 3]])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_for_each_effects_and_captures(
+    values: list[int], enabled: bool, recording: Recording
+) -> None:
+    dialects, record, recorded = recording
+
+    @dialects
+    def visit(xs: ilist.IList[int, Any], offset: int, enabled: bool) -> int:
+        def emit(x: int) -> None:
+            record(x + offset)
+
+        if enabled:
+            ilist.for_each(emit, xs)
+        return len(xs)
+
+    xs = ilist.IList(values.copy(), elem=types.Int)
+    for rewritten in (False, True):
+        if rewritten:
+            lower(visit, ForEachToForLoop(), (ilist.ForEach,))
+            loop = next(stmt for stmt in visit.code.walk() if isinstance(stmt, scf.For))
+            assert len(loop.results) == 0
+        assert visit(xs, 5, enabled) == len(values)
+        assert recorded == ([x + 5 for x in values] if enabled else [])
+        recorded.clear()
+        assert list(xs) == values
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([], (False, True)),
+        ([True], (True, True)),
+        ([False], (False, False)),
+        ([True, True], (True, True)),
+        ([False, False], (False, False)),
+        ([False, True, False], (True, False)),
+        ([True, False, True], (True, False)),
+    ],
+)
+def test_boolean_reductions(values: list[bool], expected: tuple[bool, bool]) -> None:
+    @structural_no_opt
+    def reduce(xs: ilist.IList[bool, Any]) -> tuple[bool, bool]:
+        return ilist.any(xs), ilist.all(xs)
+
+    xs = ilist.IList(values, elem=types.Bool)
+    assert reduce(xs) == expected
+    lower(
+        reduce,
+        Chain(AnyToForLoop(), AllToForLoop()),
+        (ilist.stmts.Any, ilist.stmts.All),
+    )
+    assert reduce(xs) == expected
+    loops = [stmt for stmt in reduce.code.walk() if isinstance(stmt, scf.For)]
+    assert len(loops) == 2
+    assert all(loop.results[0].type == types.Bool for loop in loops)
+
+
+def test_iteration_rules_non_match() -> None:
+    for rule in (
+        MapToForLoop(),
+        FoldToForLoop(),
+        ScanToForLoop(),
+        ForEachToForLoop(),
+        AnyToForLoop(),
+        AllToForLoop(),
+    ):
+        assert not rule.rewrite(py.Constant(1)).has_done_something
+
+
+def test_pass_rewrites_every_higher_order_statement() -> None:
+    @structural_no_opt
+    def double(x: int) -> int:
+        return 2 * x
+
+    @structural_no_opt
+    def add(acc: int, x: int) -> int:
+        return acc + x
+
+    @structural_no_opt
+    def running(acc: int, x: int) -> tuple[int, int]:
+        return acc + x, acc + x
+
+    @structural_no_opt
+    def positive(x: int) -> bool:
+        return x > 0
+
+    @structural_no_opt
+    def kernel(xs: ilist.IList[int, Any]) -> tuple[int, int, int, bool, bool]:
+        doubled = ilist.map(double, xs)
+        ilist.for_each(double, doubled)
+        signs = ilist.map(positive, doubled)
+        scanned = ilist.scan(running, doubled, 0)
+        return (
+            ilist.foldl(add, doubled, 0),
+            ilist.foldr(add, doubled, 0),
+            ilist.foldl(add, scanned[1], 0),
+            ilist.any(signs),
+            ilist.all(signs),
+        )
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    expected = kernel(xs)
+    assert expected == (12, 12, 20, True, True)
+
+    pass_ = ilist.IListToLoop(kernel.dialects, no_raise=False)
+    assert not kernel.inferred
+    assert pass_(kernel).has_done_something
+    assert kernel.inferred
+    assert not any(
+        isinstance(
+            stmt,
+            (
+                ilist.Map,
+                ilist.Foldl,
+                ilist.Foldr,
+                ilist.Scan,
+                ilist.ForEach,
+                ilist.stmts.Any,
+                ilist.stmts.All,
+            ),
+        )
+        for stmt in kernel.code.walk()
+    )
+    assert sum(isinstance(stmt, scf.For) for stmt in kernel.code.walk()) == 9
+    assert kernel(xs) == expected
+    assert list(xs) == [1, 2, 3]
+    assert not pass_(kernel).has_done_something
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("count", [0, 2])
+def test_pass_rewrites_nested_statements(enabled: bool, count: int) -> None:
+    @structural_no_opt
+    def double(x: int) -> int:
+        return 2 * x
+
+    @structural_no_opt
+    def add(acc: int, x: int) -> int:
+        return acc + x
+
+    @structural_no_opt
+    def kernel(xs: ilist.IList[int, Any], enabled: bool, count: int) -> int:
+        total = 0
+        for _ in range(count):
+            if enabled:
+                total = total + ilist.foldl(add, ilist.map(double, xs), 0)
+        return total
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    expected = kernel(xs, enabled, count)
+    assert expected == (12 * count if enabled else 0)
+    assert ilist.IListToLoop(kernel.dialects, no_raise=False)(kernel).has_done_something
+    assert not any(
+        isinstance(stmt, (ilist.Map, ilist.Foldl)) for stmt in kernel.code.walk()
+    )
+    assert kernel(xs, enabled, count) == expected
+
+
+def test_pass_leaves_unrelated_methods_unchanged() -> None:
+    @structural_no_opt
+    def kernel(xs: ilist.IList[int, Any]) -> int:
+        return len(xs)
+
+    TypeInfer(kernel.dialects, no_raise=False)(kernel)
+    assert not ilist.IListToLoop(kernel.dialects, no_raise=False)(
+        kernel
+    ).has_done_something
+    assert not any(isinstance(stmt, scf.For) for stmt in kernel.code.walk())
+
+
+def test_foldr_distinct_accumulator_type() -> None:
+    @structural_no_opt
+    def step(x: int, acc: tuple[int, int]) -> tuple[int, int]:
+        return (10 * acc[0] + x, acc[1] + 1)
+
+    @structural_no_opt
+    def folded(xs: ilist.IList[int, Any]) -> tuple[int, int]:
+        return ilist.foldr(step, xs, (0, 0))
+
+    xs = ilist.IList([1, 2, 3], elem=types.Int)
+    assert folded(xs) == (321, 3)
+    (result_type,) = lower(folded, FoldToForLoop(), (ilist.Foldr,))
+    assert result_type == types.Tuple[types.Int, types.Int]
+    folded.verify_type()
+    assert folded(xs) == (321, 3)


### PR DESCRIPTION
Adds rewrite rules and an `IListToLoop` pass that lower `Map`, `Foldl`,
`Foldr`, `Scan`, `ForEach`, `Any`, and `All` to indexed `scf.For` loops.
Callbacks remain function calls; Map and Scan build output lists through
singleton concatenation.

The PR contains two commits:

1. Fix Foldr execution and static unrolling to match its declared
   element-first callback signature:
   `foldr(f, [a, b, c], z) = f(a, f(b, f(c, z)))`.
   This changes runtime behavior for callbacks that depend on argument order.
2. Add the loop rewrites and composing pass. The pass infers types when
   needed and rewrites nested regions within the current method.

Rewriting, e.g., Map to Scf, might induce the existing SCF inference issue for growing loop-carried lists (#512). Rerunning inference after lowering could therefore infer unsound list lengths.