### PR TITLE
Fix tuple getitem type inference at constant index 0

### DIFF
--- a/src/kirin/dialects/py/indexing.py
+++ b/src/kirin/dialects/py/indexing.py
@@ -147,7 +147,8 @@ class TypeInfer(interp.MethodTable):
         obj: types.Generic,
         index: types.TypeAttribute,
     ):
-        if index_ := interp.maybe_const(stmt.index, int):
+        index_ = interp.maybe_const(stmt.index, int)
+        if index_ is not None:
             if obj.vararg and (index_ >= len(obj.vars) or -len(obj.vars) <= index_ < 0):
                 return (obj.vararg.typ,)
             elif obj.vars and (

--- a/test/dialects/pystmts/test_getitem.py
+++ b/test/dialects/pystmts/test_getitem.py
@@ -36,6 +36,11 @@ def tuple_const_index(xs: tuple[int, float, str]):
 
 
 @basic(typeinfer=True)
+def tuple_const_index_zero(xs: tuple[int, float, str]):
+    return xs[0]
+
+
+@basic(typeinfer=True)
 def tuple_err(xs: tuple[int, float, str], i: str):
     return xs[i]
 
@@ -67,6 +72,7 @@ def test_getitem_typeinfer():
         types.Tuple[types.Vararg(types.Int | types.Float | types.String)]
     )
     assert tuple_const_index.return_type.is_subseteq(types.Float)
+    assert tuple_const_index_zero.return_type.is_subseteq(types.Int)
     assert tuple_vararg_slice.return_type.is_subseteq(
         types.Tuple[types.Vararg(types.Int)]
     )


### PR DESCRIPTION
`getitem_tuple_index` tested the constant index with a walrus in an `if`, so index 0 was taken as "not a constant" and the read was typed as the union of all members. Every other constant index got its precise member type. Test the result against `None` instead.

```python
from kirin.prelude import basic

@basic(typeinfer=True)
def f(xs: tuple[int, float, str]):
    return xs[0]

print(f.return_type)  # before: Union[int, float, str]   after: int
```

Adds a `tuple_const_index_zero` case to `test/dialects/pystmts/test_getitem.py`.